### PR TITLE
메시지 생성과 스트림 런 webClient로 설정 & SSE 처리 #11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/develokit/maeum_ieum/MaeumIeumApplication.java
+++ b/src/main/java/com/develokit/maeum_ieum/MaeumIeumApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.reactive.config.EnableWebFlux;
 
 @SpringBootApplication
 @EnableJpaAuditing

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/AssistantFeignClient.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/AssistantFeignClient.java
@@ -1,7 +1,7 @@
 package com.develokit.maeum_ieum.config.openAI;
 
 
-import com.develokit.maeum_ieum.config.openAI.header.OpenAiHeaderConfiguration;
+import com.develokit.maeum_ieum.config.openAI.header.FeignHeaderConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,7 +13,7 @@ import static com.develokit.maeum_ieum.dto.openAi.assistant.RespDto.*;
 @FeignClient(
         name = "AssistantFeignClient",
         url = "https://api.openai.com/v1/assistants",
-        configuration = OpenAiHeaderConfiguration.class
+        configuration = FeignHeaderConfig.class
 )
 public interface AssistantFeignClient {
 

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/ThreadFeignClient.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/ThreadFeignClient.java
@@ -1,8 +1,7 @@
 package com.develokit.maeum_ieum.config.openAI;
 
-import com.develokit.maeum_ieum.config.openAI.header.OpenAiHeaderConfiguration;
+import com.develokit.maeum_ieum.config.openAI.header.FeignHeaderConfig;
 import com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.AudioRequestDto;
-import com.develokit.maeum_ieum.dto.openAi.message.ReqDto;
 import com.develokit.maeum_ieum.dto.openAi.message.RespDto.ListMessageRespDto;
 import com.develokit.maeum_ieum.dto.openAi.message.RespDto.MessageRespDto;
 import com.develokit.maeum_ieum.dto.openAi.run.ReqDto.CreateRunReqDto;
@@ -11,31 +10,16 @@ import com.develokit.maeum_ieum.dto.openAi.run.RespDto.RunRespDto;
 import com.develokit.maeum_ieum.dto.openAi.run.RespDto.StreamRunRespDto;
 import com.develokit.maeum_ieum.dto.openAi.thread.ReqDto.CreateThreadAndRunReqDto;
 import com.develokit.maeum_ieum.dto.openAi.thread.ReqDto.CreateThreadReqDto;
-import com.develokit.maeum_ieum.dto.openAi.thread.RespDto;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import org.hibernate.mapping.List;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-
 import static com.develokit.maeum_ieum.dto.openAi.message.ReqDto.*;
-import static com.develokit.maeum_ieum.dto.openAi.thread.ReqDto.CreateThreadReqDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.thread.RespDto.*;
 
 @FeignClient(
         name = "ThreadFeignClient",
         url = "https://api.openai.com/v1/threads",
-        configuration = OpenAiHeaderConfiguration.class
+        configuration = FeignHeaderConfig.class
 )
 public interface ThreadFeignClient {
     @PostMapping //스레드 생성
@@ -54,7 +38,7 @@ public interface ThreadFeignClient {
     ListMessageRespDto listMessages(@PathVariable("threadId") String threadId);
 
     @PostMapping("/{threadId}/runs") // 스트림 런 생성
-    StreamRunRespDto createRun(@PathVariable("threadId")String threadId, @RequestBody CreateRunReqDto createRunReqDto);
+    StreamRunRespDto createStreamRun(@PathVariable("threadId")String threadId, @RequestBody CreateRunReqDto createRunReqDto);
 
     @PostMapping("/runs") //스레드 생성 + 런 생성
     RunRespDto createThreadAndRun(@RequestBody CreateThreadAndRunReqDto createThreadAndRunReqDto);

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/ThreadWebClient.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/ThreadWebClient.java
@@ -1,0 +1,77 @@
+package com.develokit.maeum_ieum.config.openAI;
+
+import com.develokit.maeum_ieum.dto.openAi.message.ReqDto.CreateMessageReqDto;
+import com.develokit.maeum_ieum.dto.openAi.message.RespDto.MessageRespDto;
+import com.develokit.maeum_ieum.dto.openAi.run.ReqDto;
+import com.develokit.maeum_ieum.dto.openAi.run.RespDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+
+import static com.develokit.maeum_ieum.dto.openAi.run.ReqDto.*;
+import static com.develokit.maeum_ieum.dto.openAi.run.RespDto.*;
+
+@Service
+@RequiredArgsConstructor
+public class ThreadWebClient {
+
+    private final WebClient webClient;
+
+    //메시지 생성
+    public Flux<MessageRespDto> createMessage(String threadId, CreateMessageReqDto createMessageReqDto){
+        return webClient.post()
+                .uri("/{threadId}/messages", threadId)
+                .bodyValue(createMessageReqDto)
+                .retrieve()
+                .bodyToFlux(MessageRespDto.class)
+                .doOnError(WebClientResponseException.class, e -> {
+                    System.err.println("에러 코드: " + e.getStatusCode());
+                    System.err.println("에러 응답 본문: " + e.getResponseBodyAsString());
+                });
+    }
+
+    //스트림 런 생성
+    public Flux<String> createStreamRun(String threadId, CreateRunReqDto createRunReqDto){
+        return webClient.post()
+                .uri("/{threadId}/runs", threadId)
+                .bodyValue(createRunReqDto)
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+                .doOnError(WebClientResponseException.class, e -> {
+                    System.err.println("에러 코드: " + e.getStatusCode());
+                    System.err.println("에러 응답 본문: " + e.getResponseBodyAsString());
+                })
+                .filter(event -> "thread.message.delta".equals(event.event()))
+                .map(event -> {
+                    String data = event.data();
+                    try {
+                        ObjectMapper mapper = new ObjectMapper();
+                        JsonNode rootNode = mapper.readTree(data);
+                        JsonNode deltaNode = rootNode.path("delta");
+                        JsonNode contentArray = deltaNode.path("content");
+                        if (contentArray.isArray() && contentArray.size() > 0) {
+                            JsonNode textNode = contentArray.get(0).path("text");
+                            return textNode.path("value").asText();
+                        }
+                        return "";
+                    } catch (JsonProcessingException e) {
+                        e.printStackTrace();
+                        return "";
+                    }
+                });
+    }
+
+    //메시지 생성 후 스트림 런 작업 처리
+    public Flux<String> createMessageAndStreamRun(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto){
+        return createMessage(threadId, createMessageReqDto)
+                .thenMany(createStreamRun(threadId, createRunReqDto));
+
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/header/FeignHeaderConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/header/FeignHeaderConfig.java
@@ -2,14 +2,12 @@ package com.develokit.maeum_ieum.config.openAI.header;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-public class OpenAiHeaderConfiguration {
+public class FeignHeaderConfig {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
 

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/header/WebClientHeaderConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/header/WebClientHeaderConfig.java
@@ -1,0 +1,22 @@
+package com.develokit.maeum_ieum.config.openAI.header;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientHeaderConfig {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    @Value("${openai.key}")
+    private String OPENAI_API_KEY;
+    @Bean
+    public WebClient webClient(){
+        return WebClient.builder()
+                .baseUrl("https://api.openai.com/v1/threads")
+                .defaultHeader(AUTHORIZATION_HEADER,"Bearer "+OPENAI_API_KEY)
+                .defaultHeader("OpenAI-Beta", "assistants=v2")
+                .build();
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/controller/CaregiverController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/CaregiverController.java
@@ -50,7 +50,7 @@ public class CaregiverController {
         return new ResponseEntity<>(ApiUtil.success(caregiverService.attachAssistantToElderly(createAssistantReqDto, elderlyId, loginUser.getCaregiver().getUsername())),HttpStatus.CREATED);
     }
 
-    @GetMapping("/login-user") //내 정보
+    @GetMapping("/mypage") //내 정보
     public ResponseEntity<?> getCaregiverInfo(@AuthenticationPrincipal LoginUser loginUser){
         return new ResponseEntity<>(ApiUtil.success(caregiverService.caregiverInfo(loginUser.getUsername())),HttpStatus.OK);
     }

--- a/src/main/java/com/develokit/maeum_ieum/controller/ElderlyController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/ElderlyController.java
@@ -1,25 +1,38 @@
 package com.develokit.maeum_ieum.controller;
 
+import com.develokit.maeum_ieum.dto.openAi.message.ReqDto;
+import com.develokit.maeum_ieum.dto.openAi.message.ReqDto.ContentDto;
 import com.develokit.maeum_ieum.service.ElderlyService;
 import com.develokit.maeum_ieum.util.ApiUtil;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.message.StringFormattedMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 
 @RestController
-@RequestMapping("/elderlys")
+@RequestMapping("/assistants")
 @RequiredArgsConstructor
 public class ElderlyController {
 
     private final ElderlyService elderlyService;
 
+    //메인 홈
     @GetMapping("/{assistantId}")
     public ResponseEntity<?> mainHome(@PathVariable(name = "assistantId")Long assistantId){ //db의 어시스턴트 pk
         return new ResponseEntity<>(ApiUtil.success(elderlyService.mainHome(assistantId)), HttpStatus.OK);
+    }
+    //채팅 화면 들어가기
+
+    //메시지 스트림 생성
+    @PostMapping("/{openAiAssistantId}/threads/{threadId}")
+    public Flux<String> createMessage(@PathVariable(name = "openAiAssistantId")String openAiAssistantId,
+                                      @PathVariable(name = "threadId")String threadId,
+                                      @RequestBody ContentDto contentDto,
+                                      BindingResult bindingResult){
+        return elderlyService.sendMessage(openAiAssistantId, threadId, contentDto);
     }
 
 

--- a/src/main/java/com/develokit/maeum_ieum/dto/elderly/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/elderly/RespDto.java
@@ -1,5 +1,6 @@
 package com.develokit.maeum_ieum.dto.elderly;
 
+import com.develokit.maeum_ieum.domain.assistant.Assistant;
 import com.develokit.maeum_ieum.domain.user.caregiver.Caregiver;
 import com.develokit.maeum_ieum.domain.user.elderly.Elderly;
 import com.develokit.maeum_ieum.util.CustomUtil;
@@ -26,7 +27,8 @@ public class RespDto {
         private String elderlyImgUrl;
         private Long lastChatDate; //마지막 대화 'n시간 전'
         private int age;
-        public MainHomeRespDto(Caregiver caregiver, Elderly elderly){
+        private String openAiAssistantId;
+        public MainHomeRespDto(Caregiver caregiver, Elderly elderly, Assistant assistant){
             this.caregiverContact = caregiver.getContact();
             this.caregiverImgUrl = caregiver.getImgUrl();
             this.caregiverOrganization = caregiver.getOrganization();
@@ -36,6 +38,7 @@ public class RespDto {
             this.elderlyBirthdate = elderly.getBirthDate();
             this.age = CustomUtil.calculateAge(elderlyBirthdate);
             this.lastChatDate = CustomUtil.calculateHoursAgo(elderly.getLastChatTime());
+            this.openAiAssistantId = assistant.getOpenAiAssistantId();
         }
 
     }

--- a/src/main/java/com/develokit/maeum_ieum/dto/openAi/message/ReqDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/openAi/message/ReqDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ public class ReqDto {
     @Getter
     public static class ContentDto{ //프론트에서 받는 컨텐트 -> 이거 꺼내서 CreateMessageReqDto에 삽입
         @NotNull
+        @Size
         private String content;
     }
 

--- a/src/main/java/com/develokit/maeum_ieum/dto/openAi/message/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/openAi/message/RespDto.java
@@ -12,11 +12,13 @@ public class RespDto {
 
     @NoArgsConstructor
     @Getter
-    public class ListMessageRespDto{
+    public static class ListMessageRespDto{
         List<MessageRespDto> messageRespDtoList;
     }
 
-    public class MessageRespDto {
+    @Getter
+    @NoArgsConstructor
+    public static class MessageRespDto {
         private String id;
         private String object;
         @JsonProperty("created_at")

--- a/src/main/java/com/develokit/maeum_ieum/dto/openAi/run/ReqDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/openAi/run/ReqDto.java
@@ -23,7 +23,6 @@ public class ReqDto {
         @NotNull
         private String assistantId;
         private String instructions;
-        private String additionalInstruction; //런을 생성할 때, 붙이는 추가적인 instruction. 매번 인스트럭션 오버라이딩 할 필요 없이 행동 수정할 때 유용하다 함
         private AdditionalMessageDto additionalMessages;
         private boolean stream; //true이면 런 이벤트에 대한 스트림을 생성
 

--- a/src/main/java/com/develokit/maeum_ieum/dto/openAi/run/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/openAi/run/RespDto.java
@@ -14,34 +14,40 @@ import java.util.Map;
 
 public class RespDto {
 
-    @NoArgsConstructor
-    @Getter
-    public static class StreamRunRespDto{
-        private String event;
-        private StreamRunDataRespDto data;
-
         @NoArgsConstructor
         @Getter
-        public static class StreamRunDataRespDto{
-            private String id;
-            private String object;
-            private DeltaDto delta;
+        public static class StreamRunRespDto{
+            private String event;
+            private StreamRunDataRespDto data;
 
             @NoArgsConstructor
             @Getter
-            public static class DeltaDto{
-                private int index;
-                private String type;
-                private TextDto text;
+            public static class StreamRunDataRespDto{
+                private String id;
+                private String object;
+                private DeltaDto delta;
 
                 @NoArgsConstructor
                 @Getter
-                public static class TextDto{
-                    private String value;
+                public static class DeltaDto{
+                    private ContentDto content;
+
+                    @NoArgsConstructor
+                    @Getter
+                    public static class ContentDto{
+                        private int index;
+                        private String type;
+                        private TextDto text;
+
+                        @NoArgsConstructor
+                        @Getter
+                        public static class TextDto{
+                            private String value;
+                        }
+                    }
                 }
             }
         }
-    }
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/develokit/maeum_ieum/service/MessageService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/MessageService.java
@@ -1,0 +1,23 @@
+package com.develokit.maeum_ieum.service;
+
+import com.develokit.maeum_ieum.config.openAI.ThreadWebClient;
+import com.develokit.maeum_ieum.dto.openAi.message.ReqDto;
+import com.develokit.maeum_ieum.dto.openAi.run.ReqDto.CreateRunReqDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import static com.develokit.maeum_ieum.dto.openAi.message.ReqDto.*;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final ThreadWebClient threadWebClient;
+
+    public Flux<String> getStreamMessage(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto){
+        return threadWebClient.createMessageAndStreamRun(threadId, createMessageReqDto,createRunReqDto);
+    }
+
+}

--- a/src/main/java/com/develokit/maeum_ieum/service/OpenAiService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/OpenAiService.java
@@ -2,6 +2,7 @@ package com.develokit.maeum_ieum.service;
 
 import com.develokit.maeum_ieum.config.openAI.AssistantFeignClient;
 import com.develokit.maeum_ieum.config.openAI.ThreadFeignClient;
+import com.develokit.maeum_ieum.config.openAI.ThreadWebClient;
 import com.develokit.maeum_ieum.dto.openAi.message.ReqDto.CreateMessageReqDto;
 import com.develokit.maeum_ieum.dto.openAi.message.RespDto.MessageRespDto;
 import com.develokit.maeum_ieum.dto.openAi.run.ReqDto.CreateRunReqDto;
@@ -61,18 +62,7 @@ public class OpenAiService {
             throw new CustomApiException(e.getMessage());
         }
     }
-    //스트림 런
-    public StreamRunRespDto createStreamRun(String assistantId, String threadId){
-        try{
-            return threadFeignClient.createRun(threadId, new CreateRunReqDto(
-                    assistantId,
-                    true
-            ));
 
-        }catch (Exception e){
-            throw new CustomApiException(e.getMessage());
-        }
-    }
 
 
 


### PR DESCRIPTION
- FeignClient에 기재했던 '메시지 생성'과 '스트림 런' 요청 코드를 WebClient로 설정
- 메시지 생성 작업과 답변 스트림 생성 작업을 비동기 순차적으로 처리하고 결과를 결합해서 반환
```java
public Flux<String> createMessageAndStreamRun(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto) {
    return createMessage(threadId, createMessageReqDto)
            .thenMany(createStreamRun(threadId, createRunReqDto));
}
```
- ``파라미터`` :  threadId와 메시지 생성 요청 DTO, 스트림 실행 요청 DTO
- ``처리 과정`` : createMessage(threadId, createMessageReqDto) 실행 -> 완료되면 thenMany로 createStreamRun(threadId, createRunReqDto) 실행 -> 문자열 데이터 스트림 반환 


응답을 SSE로 받기 때문인지 직접적인 DTO 매핑이 이뤄지지 않았다. 따라서 우선 문자열로 수신한 후 Json으로 변환해서 파싱했다.
우선 전체적으로 JsonNode 사용해서 데이터를 뽑아내긴 했는데,  ServerSentEvent<String>으로 받은 후에는 DTO로 매핑 가능할 것 같다. 이 부분은 다시 확인해봐야겠다



