### PR TITLE
webClient 오디오 응답 반환 & SecurityConfig 접근 권한 에러 핸들러 생성

### DIFF
--- a/src/main/java/com/develokit/maeum_ieum/config/SecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/SecurityConfig.java
@@ -3,10 +3,14 @@ package com.develokit.maeum_ieum.config;
 import com.develokit.maeum_ieum.config.jwt.JwtAuthenticationFilter;
 import com.develokit.maeum_ieum.config.jwt.JwtAuthorizationFilter;
 import com.develokit.maeum_ieum.domain.user.Role;
+import com.develokit.maeum_ieum.util.ApiUtil;
+import com.develokit.maeum_ieum.util.api.ApiResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -58,7 +62,19 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS) //토큰 쓸 거라서 해제
-                );
+                )
+                .exceptionHandling(handler -> {
+                    handler.accessDeniedHandler((request, response, accessDeniedException) -> {
+                        ObjectMapper om = new ObjectMapper();
+                        ApiResult<?> responseDto = ApiUtil.error("로그인을 진행해주세요", HttpStatus.FORBIDDEN.value());
+                        String responseBody = om.writeValueAsString(responseDto);
+
+                        response.setContentType("application/json; charset=utf-8");
+                        response.setStatus(403);
+                        response.getWriter().println(responseBody); //만약 response status가 403이면, 그 response를 가로채고 내용을 "error"로 바꿈
+                    });
+                })
+        ;
 
 
         return http.build();

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/ThreadWebClient.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/ThreadWebClient.java
@@ -1,12 +1,19 @@
 package com.develokit.maeum_ieum.config.openAI;
 
+import com.develokit.maeum_ieum.dto.message.RespDto.CreateStreamMessageRespDto;
+import com.develokit.maeum_ieum.dto.openAi.audio.ReqDto;
+import com.develokit.maeum_ieum.dto.openAi.audio.RespDto.CreateAudioRespDto;
 import com.develokit.maeum_ieum.dto.openAi.message.ReqDto.CreateMessageReqDto;
 import com.develokit.maeum_ieum.dto.openAi.message.RespDto.MessageRespDto;
-import com.develokit.maeum_ieum.dto.openAi.run.ReqDto;
 import com.develokit.maeum_ieum.dto.openAi.run.RespDto;
+import com.develokit.maeum_ieum.dto.openAi.run.RespDto.StreamRunRespDto;
+import com.develokit.maeum_ieum.ex.CustomApiException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.codec.ServerSentEvent;
@@ -14,20 +21,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import static com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.run.ReqDto.*;
-import static com.develokit.maeum_ieum.dto.openAi.run.RespDto.*;
+
 
 @Service
 @RequiredArgsConstructor
 public class ThreadWebClient {
 
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
 
     //메시지 생성
     public Flux<MessageRespDto> createMessage(String threadId, CreateMessageReqDto createMessageReqDto){
         return webClient.post()
-                .uri("/{threadId}/messages", threadId)
+                .uri("/threads/{threadId}/messages", threadId)
                 .bodyValue(createMessageReqDto)
                 .retrieve()
                 .bodyToFlux(MessageRespDto.class)
@@ -37,10 +47,23 @@ public class ThreadWebClient {
                 });
     }
 
-    //스트림 런 생성
-    public Flux<String> createStreamRun(String threadId, CreateRunReqDto createRunReqDto){
+    public Mono<MessageRespDto> createSingleMessage(String threadId, CreateMessageReqDto createMessageReqDto){
+        System.out.println("===메시지 생성 함수 시작===");
         return webClient.post()
-                .uri("/{threadId}/runs", threadId)
+                .uri("/threads/{threadId}/messages",threadId)
+                .bodyValue(createMessageReqDto)
+                .retrieve()
+                .bodyToMono(MessageRespDto.class)
+                .doOnError(WebClientResponseException.class, e -> {
+                    System.err.println("에러 코드: " + e.getStatusCode());
+                    System.err.println("에러 응답 본문: " + e.getResponseBodyAsString());
+                });
+    }
+
+    //스트림 런 생성
+    public Flux<CreateStreamMessageRespDto> createStreamRun(String threadId, CreateRunReqDto createRunReqDto){
+        return webClient.post()
+                .uri("/threads/{threadId}/runs", threadId)
                 .bodyValue(createRunReqDto)
                 .retrieve()
                 .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
@@ -58,20 +81,84 @@ public class ThreadWebClient {
                         JsonNode contentArray = deltaNode.path("content");
                         if (contentArray.isArray() && contentArray.size() > 0) {
                             JsonNode textNode = contentArray.get(0).path("text");
-                            return textNode.path("value").asText();
+                            String answer = textNode.path("value").asText();
+                            return new CreateStreamMessageRespDto(answer);
                         }
-                        return "";
+                        return null; //TODO 이거 처리할것!!!
                     } catch (JsonProcessingException e) {
                         e.printStackTrace();
-                        return "";
+                        return null; //TODO 이거 처리할것!!!
                     }
                 });
     }
 
     //메시지 생성 후 스트림 런 작업 처리
-    public Flux<String> createMessageAndStreamRun(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto){
+    public Flux<CreateStreamMessageRespDto> createMessageAndStreamRun(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto){
         return createMessage(threadId, createMessageReqDto)
                 .thenMany(createStreamRun(threadId, createRunReqDto));
 
     }
+
+    //비스트림 런 생성 (생성된 전체 답변)
+    Mono<String> createRun(String threadId, CreateRunReqDto createRunReqDto){
+        return webClient.post()
+                .uri("/threads/{threadId}/runs", threadId)
+                .bodyValue(createRunReqDto)
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {}) //SSE 스트림
+                .doOnError(WebClientResponseException.class, e -> {
+                    System.err.println("에러 코드: " + e.getStatusCode());
+                    System.err.println("에러 응답 본문: " + e.getResponseBodyAsString());
+                    throw new CustomApiException(e.getMessage());
+                })
+                .filter(event -> "thread.message.completed".equals(event.event()))
+                .next()
+                .flatMap(event -> {
+                    String data = event.data();
+                    try {
+                        ObjectMapper mapper = new ObjectMapper();
+                        JsonNode rootNode = mapper.readTree(data);
+                        JsonNode contentArray = rootNode.path("content");
+                        if (contentArray.isArray() && contentArray.size() > 0) {
+                            JsonNode textNode = contentArray.get(0).path("text");
+                            System.out.println(textNode.path("value").asText());
+                            return Mono.just(textNode.path("value").asText());
+                        }
+                        return Mono.just("");
+                    } catch (JsonProcessingException e) {
+                        e.printStackTrace();
+                        return Mono.error(e);
+                    }
+                })
+                .doOnNext(text -> System.out.println("text = " + text));
+    }
+
+    //오디오 생성
+    public Mono<CreateAudioRespDto> createAudio(AudioRequestDto audioRequestDto){
+        return webClient.post()
+                .uri("/audio/speech")
+                .bodyValue(audioRequestDto)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .map(bytes -> new CreateAudioRespDto(bytes))
+                .doOnError(WebClientResponseException.class, e -> {
+                    System.err.println("에러 코드: " + e.getStatusCode());
+                    System.err.println("에러 응답 본문: " + e.getResponseBodyAsString());
+                });
+    }
+
+    // 메시지 생성 -> 답변 생성 -> 답변을 오디오로 변환
+    public Mono<CreateAudioRespDto> createMessageAndRun(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto, AudioRequestDto audioRequestDto){
+        return createSingleMessage(threadId, createMessageReqDto)
+                .then(createRun(threadId, createRunReqDto))
+                .flatMap(text -> {
+                    audioRequestDto.setInput(text);
+                    return createAudio(audioRequestDto);
+                });
+    }
+
+
+
+
+
 }

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/header/WebClientHeaderConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/header/WebClientHeaderConfig.java
@@ -3,6 +3,7 @@ package com.develokit.maeum_ieum.config.openAI.header;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -14,9 +15,11 @@ public class WebClientHeaderConfig {
     @Bean
     public WebClient webClient(){
         return WebClient.builder()
-                .baseUrl("https://api.openai.com/v1/threads")
+                .baseUrl("https://api.openai.com/v1")
                 .defaultHeader(AUTHORIZATION_HEADER,"Bearer "+OPENAI_API_KEY)
                 .defaultHeader("OpenAI-Beta", "assistants=v2")
+                .exchangeStrategies(ExchangeStrategies.builder().codecs(clientCodecConfigurer -> clientCodecConfigurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
+                        .build())
                 .build();
     }
 }

--- a/src/main/java/com/develokit/maeum_ieum/controller/CaregiverController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/CaregiverController.java
@@ -35,7 +35,7 @@ public class CaregiverController {
     }
 
     @PostMapping("/elderlys")
-    public ResponseEntity<?> createElderly(@RequestBody ElderlyCreateReqDto elderlyCreateReqDto,
+    public ResponseEntity<?> createElderly(@Valid @RequestBody ElderlyCreateReqDto elderlyCreateReqDto,
                                            BindingResult bindingResult,
                                            @AuthenticationPrincipal LoginUser loginUser
                                            ){

--- a/src/main/java/com/develokit/maeum_ieum/controller/ElderlyController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/ElderlyController.java
@@ -1,9 +1,21 @@
 package com.develokit.maeum_ieum.controller;
 
+import com.develokit.maeum_ieum.config.openAI.ThreadWebClient;
+import com.develokit.maeum_ieum.dto.message.ReqDto.CreateStreamMessageReqDto;
+import com.develokit.maeum_ieum.dto.message.RespDto;
+import com.develokit.maeum_ieum.dto.openAi.audio.RespDto.CreateAudioRespDto;
 import com.develokit.maeum_ieum.dto.openAi.message.ReqDto;
 import com.develokit.maeum_ieum.dto.openAi.message.ReqDto.ContentDto;
+import com.develokit.maeum_ieum.ex.CustomApiException;
+import com.develokit.maeum_ieum.service.AssistantService;
 import com.develokit.maeum_ieum.service.ElderlyService;
+import com.develokit.maeum_ieum.service.MessageService;
 import com.develokit.maeum_ieum.util.ApiUtil;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.message.StringFormattedMessage;
 import org.springframework.http.HttpStatus;
@@ -11,29 +23,79 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.develokit.maeum_ieum.dto.message.RespDto.*;
+import static com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.*;
 
 @RestController
-@RequestMapping("/assistants")
+@RequestMapping("/elderlys")
 @RequiredArgsConstructor
 public class ElderlyController {
 
     private final ElderlyService elderlyService;
+    private final MessageService messageService;
+    private final AssistantService assistantService;
+
+    //접속 코드 확인
+    @GetMapping
+    public ResponseEntity<?> verifyAccessCode(@RequestParam(name = "access-code")String accessCode){
+        return new ResponseEntity<>(ApiUtil.success(assistantService.verifyAccessCode(accessCode)),HttpStatus.OK);
+    }
 
     //메인 홈
-    @GetMapping("/{assistantId}")
-    public ResponseEntity<?> mainHome(@PathVariable(name = "assistantId")Long assistantId){ //db의 어시스턴트 pk
-        return new ResponseEntity<>(ApiUtil.success(elderlyService.mainHome(assistantId)), HttpStatus.OK);
+    @GetMapping("/{elderlyId}/assistants/{assistantId}")
+    public ResponseEntity<?> mainHome(@PathVariable(name = "elderlyId")Long elderlyId, @PathVariable(name = "assistantId")Long assistantId){ //db의 어시스턴트 pk
+        return new ResponseEntity<>(ApiUtil.success(elderlyService.mainHome(elderlyId, assistantId)), HttpStatus.OK);
     }
     //채팅 화면 들어가기
 
+
+
     //메시지 스트림 생성
-    @PostMapping("/{openAiAssistantId}/threads/{threadId}")
-    public Flux<String> createMessage(@PathVariable(name = "openAiAssistantId")String openAiAssistantId,
-                                      @PathVariable(name = "threadId")String threadId,
-                                      @RequestBody ContentDto contentDto,
-                                      BindingResult bindingResult){
-        return elderlyService.sendMessage(openAiAssistantId, threadId, contentDto);
+    @PostMapping("/{elderlyId}/stream-message")
+    public Flux<CreateStreamMessageRespDto> createStreamMessage(
+            @PathVariable(name = "elderlyId") Long elderlyId,
+            @RequestBody CreateStreamMessageReqDto createStreamMessageReqDto,
+                                                                BindingResult bindingResult){
+        elderlyService.updateLastChatDate(elderlyId);
+        return messageService.getStreamMessage(createStreamMessageReqDto);
     }
+
+    @PostMapping("/{elderlyId}/voice-message")
+    public Mono<?> createVoiceMessage(@PathVariable(name = "elderlyId")Long elderlyId,
+                                                       @Valid @RequestBody CreateAudioReqDto createAudioReqDto,
+                                                       BindingResult bindingResult){
+        elderlyService.updateLastChatDate(elderlyId);
+
+        return messageService.getVoiceMessage(createAudioReqDto)
+//                .flatMap(voiceMessage -> saveVoiceMessageToFile(voiceMessage, "C:\\Users\\admin\\Desktop\\maeum-ieum\\src\\main\\resources\\마음이음.mp3")
+//                        .then(Mono.just(voiceMessage)))
+                .map(result -> new ResponseEntity<>(ApiUtil.success(result), HttpStatus.CREATED))
+                .doOnError(e -> {
+                    System.err.println("에러 발생: " + e.getMessage());
+                    throw new CustomApiException(e.getMessage());
+                });
+    }
+
+    public Mono<String>saveVoiceMessageToFile(CreateAudioRespDto voiceMessage, String fileName){
+        return Mono.fromCallable(() -> {
+            try{
+                Path path = Paths.get(fileName);
+                Files.write(path, voiceMessage.getAnswer());
+                return "file Path : " + path.toAbsolutePath().toString();
+            }catch (IOException e){
+                throw new RuntimeException("Error while saving file", e);
+            }
+        });
+    }
+
+
 
 
 

--- a/src/main/java/com/develokit/maeum_ieum/domain/assistant/Assistant.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/assistant/Assistant.java
@@ -23,6 +23,9 @@ public class Assistant extends BaseEntity {
     private String openAiAssistantId; //실제 OpenAI에 등록되는 어시스턴트 아이디
     private String name;
 
+    @Column(length = 5)
+    private String accessCode;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "caregiver_id")
     private Caregiver caregiver;
@@ -52,7 +55,7 @@ public class Assistant extends BaseEntity {
 
 
     @Builder
-    public Assistant(String name, Caregiver caregiver, Elderly elderly, String rule, String conversationTopic, String responseType, String personality, String forbiddenTopic, String openAiAssistantId) {
+    public Assistant(String name, Caregiver caregiver, Elderly elderly, String rule, String conversationTopic, String responseType, String personality, String forbiddenTopic, String openAiAssistantId, String accessCode) {
         this.name = name;
         this.caregiver = caregiver;
         this.elderly = elderly;
@@ -62,6 +65,7 @@ public class Assistant extends BaseEntity {
         this.personality = personality;
         this.forbiddenTopic = forbiddenTopic;
         this.openAiAssistantId = openAiAssistantId;
+        this.accessCode = accessCode;
         caregiver.getAssistantList().add(this);
     }
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/assistant/AssistantRepository.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/assistant/AssistantRepository.java
@@ -3,6 +3,10 @@ package com.develokit.maeum_ieum.domain.assistant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AssistantRepository extends JpaRepository<Assistant, Long> {
+
+    Optional<Assistant> findByAccessCode(String accessCode);
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/user/Gender.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/user/Gender.java
@@ -1,6 +1,10 @@
 package com.develokit.maeum_ieum.domain.user;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
+@Getter
 public enum Gender {
 
 

--- a/src/main/java/com/develokit/maeum_ieum/domain/user/elderly/Elderly.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/user/elderly/Elderly.java
@@ -47,6 +47,9 @@ public class Elderly extends User {
         this.assistant = assistant;
     }
 
+    public void updateLastChatDate(LocalDateTime lastChatTime){
+        this.lastChatTime = lastChatTime;
+    }
     @Builder
     public Elderly(String name, String contact, Gender gender, String imgUrl, LocalDate birthDate, String organization, String healthInfo, String homeAddress, Caregiver caregiver, Assistant assistant, EmergencyContactInfo emergencyContactInfo, Role role) {
         super(name, contact, gender, imgUrl, birthDate, organization, role);

--- a/src/main/java/com/develokit/maeum_ieum/dto/assistant/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/assistant/RespDto.java
@@ -1,0 +1,22 @@
+package com.develokit.maeum_ieum.dto.assistant;
+
+import com.develokit.maeum_ieum.domain.assistant.Assistant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RespDto {
+
+    @NoArgsConstructor
+    @Getter
+    public static class VerifyAccessCodeRespDto{
+        private Long assistantId;
+        private String openAiAssistantId;
+        private Long elderlyId;
+
+        public VerifyAccessCodeRespDto(Assistant assistant){
+            this.assistantId = assistant.getId();
+            this.openAiAssistantId = assistant.getOpenAiAssistantId();
+            this.elderlyId = assistant.getElderly().getId();
+        }
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/dto/elderly/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/elderly/RespDto.java
@@ -27,8 +27,7 @@ public class RespDto {
         private String elderlyImgUrl;
         private Long lastChatDate; //마지막 대화 'n시간 전'
         private int age;
-        private String openAiAssistantId;
-        public MainHomeRespDto(Caregiver caregiver, Elderly elderly, Assistant assistant){
+        public MainHomeRespDto(Caregiver caregiver, Elderly elderly){
             this.caregiverContact = caregiver.getContact();
             this.caregiverImgUrl = caregiver.getImgUrl();
             this.caregiverOrganization = caregiver.getOrganization();
@@ -38,7 +37,6 @@ public class RespDto {
             this.elderlyBirthdate = elderly.getBirthDate();
             this.age = CustomUtil.calculateAge(elderlyBirthdate);
             this.lastChatDate = CustomUtil.calculateHoursAgo(elderly.getLastChatTime());
-            this.openAiAssistantId = assistant.getOpenAiAssistantId();
         }
 
     }

--- a/src/main/java/com/develokit/maeum_ieum/dto/message/ReqDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/message/ReqDto.java
@@ -1,0 +1,22 @@
+package com.develokit.maeum_ieum.dto.message;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ReqDto {
+    @Getter
+    @NoArgsConstructor
+    public static class CreateStreamMessageReqDto{
+        @NotNull(message = "content를 기재해야 합니다")
+        private String content;
+
+        @NotNull(message = "openAiAssistantId를 기재해야 합니다")
+        private String openAiAssistantId;
+
+        @NotNull(message = "threadId를 기재해야 합니다")
+        private String threadId;
+
+    }
+
+}

--- a/src/main/java/com/develokit/maeum_ieum/dto/message/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/message/RespDto.java
@@ -1,0 +1,16 @@
+package com.develokit.maeum_ieum.dto.message;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RespDto {
+
+    @NoArgsConstructor
+    @Getter
+    public static class CreateStreamMessageRespDto{
+        private String answer;
+        public CreateStreamMessageRespDto(String answer){
+            this.answer = answer;
+        }
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/dto/openAi/audio/ReqDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/openAi/audio/ReqDto.java
@@ -1,20 +1,41 @@
 package com.develokit.maeum_ieum.dto.openAi.audio;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.develokit.maeum_ieum.domain.user.Gender;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
 
 public class ReqDto {
+
+    @NoArgsConstructor
+    @Getter
+    public static class CreateAudioReqDto{
+        @NotNull(message = "content를 기재해야 합니다")
+        private String content;
+
+        @NotNull(message = "openAiAssistantId를 기재해야 합니다")
+        private String openAiAssistantId;
+
+        @NotNull(message = "threadId를 기재해야 합니다")
+        private String threadId;
+
+        @Pattern(regexp = "^(FEMALE|MALE)$", message = "성별은 FEMALE 또는 MALE이어야 합니다")
+        private String gender;
+    }
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Setter
     public static class AudioRequestDto{
         private String model;
         private String voice;
         private String input;
 
+        public AudioRequestDto(String model, String voice) {
+            this.model = model;
+            this.voice = voice;
+        }
     }
 }

--- a/src/main/java/com/develokit/maeum_ieum/dto/openAi/audio/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/openAi/audio/RespDto.java
@@ -1,0 +1,15 @@
+package com.develokit.maeum_ieum.dto.openAi.audio;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RespDto {
+
+    @NoArgsConstructor
+    @Getter
+    @AllArgsConstructor
+    public static class CreateAudioRespDto{
+        private byte[] answer;
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/service/AssistantService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/AssistantService.java
@@ -1,0 +1,37 @@
+package com.develokit.maeum_ieum.service;
+
+import com.develokit.maeum_ieum.domain.assistant.Assistant;
+import com.develokit.maeum_ieum.domain.assistant.AssistantRepository;
+import com.develokit.maeum_ieum.dto.assistant.RespDto;
+import com.develokit.maeum_ieum.ex.CustomApiException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.develokit.maeum_ieum.dto.assistant.RespDto.*;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class AssistantService {
+
+    private final AssistantRepository assistantRepository;
+
+    public VerifyAccessCodeRespDto verifyAccessCode(String accessCode){
+        Assistant assistantPS = assistantRepository.findByAccessCode(accessCode)
+                .orElseThrow(
+                        () -> new CustomApiException("코드를 다시 확인해주세요")
+                );
+
+        if(assistantPS.getElderly() == null)
+            throw new CustomApiException("사용할 수 없는 AI 어시서턴트 입니다");
+
+        return new VerifyAccessCodeRespDto(assistantPS);
+    }
+
+
+
+
+}

--- a/src/main/java/com/develokit/maeum_ieum/service/CaregiverService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/CaregiverService.java
@@ -124,6 +124,7 @@ public class CaregiverService {
                         .responseType(createAssistantReqDto.getResponseType())
                         .personality(createAssistantReqDto.getPersonality())
                         .forbiddenTopic(createAssistantReqDto.getForbiddenTopic())
+                        .accessCode(bCryptPasswordEncoder.encode(elderlyPS.getName()))
                         .build()
         );
 

--- a/src/main/java/com/develokit/maeum_ieum/service/MessageService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/MessageService.java
@@ -1,13 +1,25 @@
 package com.develokit.maeum_ieum.service;
 
 import com.develokit.maeum_ieum.config.openAI.ThreadWebClient;
+import com.develokit.maeum_ieum.controller.ElderlyController;
+import com.develokit.maeum_ieum.domain.user.Gender;
+import com.develokit.maeum_ieum.dto.message.ReqDto.CreateStreamMessageReqDto;
+import com.develokit.maeum_ieum.dto.message.RespDto;
+import com.develokit.maeum_ieum.dto.message.RespDto.CreateStreamMessageRespDto;
+import com.develokit.maeum_ieum.dto.openAi.audio.RespDto.CreateAudioRespDto;
 import com.develokit.maeum_ieum.dto.openAi.message.ReqDto;
 import com.develokit.maeum_ieum.dto.openAi.run.ReqDto.CreateRunReqDto;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import static com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.message.ReqDto.*;
 
 @Service
@@ -16,8 +28,37 @@ public class MessageService {
 
     private final ThreadWebClient threadWebClient;
 
-    public Flux<String> getStreamMessage(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto){
-        return threadWebClient.createMessageAndStreamRun(threadId, createMessageReqDto,createRunReqDto);
+    //채팅 하기 -> 스레드 아이디, 어시스턴트 아이디, 요청 보낼 메시지 DTO 필요
+    public Flux<CreateStreamMessageRespDto> getStreamMessage(CreateStreamMessageReqDto createStreamMessageReqDto){
+        return threadWebClient.createMessageAndStreamRun(
+                createStreamMessageReqDto.getThreadId(),
+                new CreateMessageReqDto(
+                        "user",
+                        createStreamMessageReqDto.getContent()
+                ),
+                new CreateRunReqDto(
+                        createStreamMessageReqDto.getOpenAiAssistantId(),
+                        true
+                )
+        );
     }
+    public Mono<CreateAudioRespDto> getVoiceMessage(CreateAudioReqDto createAudioReqDto){
+        return threadWebClient.createMessageAndRun(
+                createAudioReqDto.getThreadId(),
+                new CreateMessageReqDto(
+                        "user",
+                        createAudioReqDto.getContent()
+                ),
+                new CreateRunReqDto(
+                        createAudioReqDto.getOpenAiAssistantId(),
+                        true
+                ),
+                new AudioRequestDto(
+                        "tts-1",
+                        createAudioReqDto.getGender().equals("FEMALE")?"nova":"onyx"
+                )
+        );
+    }
+
 
 }


### PR DESCRIPTION
## 1. 
런을 스트림으로 받은 후 event 상태가 thread.message.completed가 될 때 해당 답변 추출 후 createAudio 함수의 인자로 넘겨서 바이트 파일 생성 

```java
  // 메시지 생성 -> 답변 생성 -> 답변을 오디오로 변환
public Mono<CreateAudioRespDto> createMessageAndRun(String threadId, CreateMessageReqDto createMessageReqDto, CreateRunReqDto createRunReqDto, AudioRequestDto audioRequestDto){
        return createSingleMessage(threadId, createMessageReqDto)
                .then(createRun(threadId, createRunReqDto))
                .flatMap(text -> {
                    audioRequestDto.setInput(text);
                    return createAudio(audioRequestDto);
                });
    }
```

## 2. 
접근 거부 핸들러 설정 -> 로그인을 진행해 달라는 에러로 응답