### PR TITLE
주간 보고서 배치 기능 및 스레드 관련 기능 추가

### DIFF
--- a/src/main/java/com/develokit/maeum_ieum/MaeumIeumApplication.java
+++ b/src/main/java/com/develokit/maeum_ieum/MaeumIeumApplication.java
@@ -1,5 +1,6 @@
 package com.develokit.maeum_ieum;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;

--- a/src/main/java/com/develokit/maeum_ieum/config/SecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(configurationSource()))
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/caregivers","/check-username/{username}").permitAll()
                     //.requestMatchers("/caregivers/elderlys").hasAuthority("ROLE_ADMIN")
                         //.requestMatchers("/caregivers/elderlys", "/caregivers", "/caregivers/elderlys/{elderlyId}/assistants", "/caregivers/mypage", "caregivers/mypage/image", "/caregivers/elderlys/{elderlyId}/image", "/caregivers/elderlys/{elderlyId}/assistants/{assistantId}").authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/com/develokit/maeum_ieum/config/batch/BatchConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/batch/BatchConfig.java
@@ -1,0 +1,10 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/batch/ReportGenerationScheduler.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/batch/ReportGenerationScheduler.java
@@ -1,0 +1,41 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class ReportGenerationScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job weeklyReportGenerationJob;
+    private final Logger log = LoggerFactory.getLogger(ReportProcessor.class);
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행 (보고서 분석 결과 기록)
+    public void runReportGenerationJob() throws Exception {
+
+        LocalDateTime today = LocalDateTime.now();
+
+        //기존 보고서 처리(분석 결과 반영)
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", Date.from(today.atZone(ZoneId.systemDefault()).toInstant()))
+                .toJobParameters();
+        JobExecution jobExecution = jobLauncher.run(weeklyReportGenerationJob, jobParameters);
+
+        //Job 완료 확인
+        if (jobExecution.getStatus() != BatchStatus.COMPLETED) {
+            // Job 실패 처리
+            log.error("주간 보고서 생성 Job 실패: " + jobExecution.getStatus());
+            //재시도 로직이나.. job 실패 시 어떻게 할지는 모르겠음
+        }
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/batch/ReportJobConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/batch/ReportJobConfig.java
@@ -1,0 +1,86 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import com.develokit.maeum_ieum.domain.report.Report;
+import com.develokit.maeum_ieum.domain.report.ReportRepository;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.develokit.maeum_ieum.config.batch.ReportProcessor.*;
+
+@Configuration
+@RequiredArgsConstructor
+public class ReportJobConfig {
+    private final PlatformTransactionManager transactionManager;
+    private final JobRepository jobRepository;
+
+
+    @Bean
+    public Job weeklyReportGenerationJob(Step reportGenerationStep, JobRepository repository){
+        return new JobBuilder("weeklyReportGenerationJob", repository)
+                .start(reportGenerationStep)
+                .build();
+    }
+
+    //보고서 저장
+    @Bean
+    public JpaItemWriter<Report> reportWriter(EntityManagerFactory entityManagerFactory) {
+        JpaItemWriter<Report> writer = new JpaItemWriter<>();
+        writer.setEntityManagerFactory(entityManagerFactory);
+        return writer;
+    }
+    //보고서 페이징 크기:100
+    @Bean
+    public JpaPagingItemReader<Report> reportReader(EntityManagerFactory entityManagerFactory) {
+
+        Map<String, Object> parameterValues = new HashMap<>();
+
+        LocalDate today = LocalDate.now();
+        parameterValues.put("reportDay", today.getDayOfWeek());
+        parameterValues.put("today", today);
+        parameterValues.put("sevenDaysAgo", today.minusDays(7)); //일주일 이상까지 대기 상태인 보고서들 땡겨오기
+
+        return new JpaPagingItemReaderBuilder<Report>()
+                .name("reportReader")
+                .entityManagerFactory(entityManagerFactory)
+                .pageSize(100)
+                .queryString("select r from Report r where r.status = 'PENDING' and r.reportDay = :reportDay and r.startDate <= :sevenDaysAgo")
+                .parameterValues(parameterValues)
+                .build();
+    }
+
+    //보고서 생성 위한 청크 구성
+    @Bean
+    public Step reportGenerationStep(ItemReader<Report> reader,
+                                     ItemProcessor<Report, ReportProcessResult> processor,
+                                     ItemWriter<ReportProcessResult> writer
+                                     ){
+
+        return new StepBuilder("reportGenerationStep", jobRepository)
+                .<Report, ReportProcessResult>chunk(100, transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/batch/ReportProcessor.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/batch/ReportProcessor.java
@@ -1,0 +1,71 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import com.develokit.maeum_ieum.domain.report.Report;
+import com.develokit.maeum_ieum.domain.report.ReportStatus;
+import com.develokit.maeum_ieum.ex.CustomApiException;
+import com.develokit.maeum_ieum.service.ReportService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.develokit.maeum_ieum.config.batch.ReportProcessor.*;
+
+@Component
+@RequiredArgsConstructor
+public class ReportProcessor implements ItemProcessor<Report, ReportProcessResult> {
+
+    private final ReportService reportService;
+    private final Logger log = LoggerFactory.getLogger(ReportProcessor.class);
+
+    @Override
+    public ReportProcessResult process(Report report) throws Exception {
+        ReportProcessResult result = new ReportProcessResult();
+        try {
+            log.info("보고서 분석 작업 시작: {}", report.getElderly().getId());
+            //보고서 상태 변경: 대기 -> 분석 진행 중
+            report.updateReportStatus(ReportStatus.PROCESSING);
+
+            //분석 시작
+            reportService.generateReportContent(report);
+
+            //보고서 상태 변경: 분석 진행 중 -> 분석 완료
+            LocalDateTime today = LocalDateTime.now();
+            report.updateReportStatus(ReportStatus.COMPLETED);
+            report.updateEndDate(today);
+
+            //다음 주기의 빈 보고서 생성
+            Report nextReport = Report.builder()
+                    .reportDay(report.getReportDay())
+                    .reportStatus(ReportStatus.PENDING)
+                    .startDate(today)
+                    .elderly(report.getElderly())
+                    .build();
+
+            result.setCompletedReport(report);
+            result.setNextReport(nextReport);
+            log.info("보고서 결과 반영 성공: {}", report.getElderly().getId());
+
+        }catch (Exception e){
+            log.error("보고서 분석 중 오류 발생: elderlyId = {}, error = {}", report.getElderly().getId(), e.getMessage());
+            report.updateReportStatus(ReportStatus.ERROR);
+            //스프링 배치에 에러 던지는 방향으로 수정할 수 있을듯 (재시작 로직에 대한 요청같은)
+            throw new CustomApiException("보고서 배치 처리 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return result;
+    }
+    @Getter
+    @Setter
+    public static class ReportProcessResult{
+        private Report completedReport;
+        private Report nextReport;
+    }
+
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/batch/ReportWriter.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/batch/ReportWriter.java
@@ -1,0 +1,29 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import com.develokit.maeum_ieum.domain.report.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.develokit.maeum_ieum.config.batch.ReportProcessor.*;
+
+
+@Component
+@RequiredArgsConstructor
+public class ReportWriter implements ItemWriter<ReportProcessResult> {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public void write(Chunk<? extends ReportProcessResult> chunk) throws Exception {
+        for (ReportProcessResult result : chunk.getItems()) {
+            reportRepository.save(result.getCompletedReport());
+            if (result.getNextReport() != null) {
+                reportRepository.save(result.getNextReport());
+            }
+        }
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/loginUser/LoginUserService.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/loginUser/LoginUserService.java
@@ -16,10 +16,15 @@ public class LoginUserService implements UserDetailsService {
 
     private final CareGiverRepository careGiverRepository;
 
+
+
+    //실제 DB에 있는지 체크
+    //DB에 없으면 new internalAuthenticationServiceException throw
+    //DB에 있으면 Userdatils를 세션에 저장 -> 로그인 성공
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Caregiver caregiver = careGiverRepository.findByUsername(username)
                 .orElseThrow(() -> new InternalAuthenticationServiceException("인증 실패"));
-        return new LoginUser(caregiver);
+        return new LoginUser(caregiver); //세션에 담기
     }
 }

--- a/src/main/java/com/develokit/maeum_ieum/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/websocket/WebSocketConfig.java
@@ -12,7 +12,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.enableSimpleBroker("/topic");
-        config.setApplicationDestinationPrefixes("/app");
+        //config.setApplicationDestinationPrefixes("/app");
     }
 
     @Override

--- a/src/main/java/com/develokit/maeum_ieum/controller/ElderlyController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/ElderlyController.java
@@ -1,12 +1,7 @@
 package com.develokit.maeum_ieum.controller;
 
-import com.develokit.maeum_ieum.config.openAI.ThreadWebClient;
-import com.develokit.maeum_ieum.domain.emergencyRequest.EmergencyRequest;
 import com.develokit.maeum_ieum.dto.message.ReqDto.CreateStreamMessageReqDto;
-import com.develokit.maeum_ieum.dto.message.RespDto;
 import com.develokit.maeum_ieum.dto.openAi.audio.RespDto.CreateAudioRespDto;
-import com.develokit.maeum_ieum.dto.openAi.message.ReqDto;
-import com.develokit.maeum_ieum.dto.openAi.message.ReqDto.ContentDto;
 import com.develokit.maeum_ieum.ex.CustomApiException;
 import com.develokit.maeum_ieum.service.AssistantService;
 import com.develokit.maeum_ieum.service.ElderlyService;
@@ -15,15 +10,7 @@ import com.develokit.maeum_ieum.service.MessageService;
 import com.develokit.maeum_ieum.util.ApiUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.StringFormattedMessage;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -35,10 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static com.develokit.maeum_ieum.dto.assistant.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.emergencyRequest.ReqDto.*;
-import static com.develokit.maeum_ieum.dto.emergencyRequest.RespDto.*;
 import static com.develokit.maeum_ieum.dto.message.RespDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.*;
 

--- a/src/main/java/com/develokit/maeum_ieum/controller/ElderlyControllerDocs.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/ElderlyControllerDocs.java
@@ -1,7 +1,5 @@
 package com.develokit.maeum_ieum.controller;
 
-import com.develokit.maeum_ieum.dto.assistant.ReqDto;
-import com.develokit.maeum_ieum.dto.elderly.RespDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -18,13 +16,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import static com.develokit.maeum_ieum.dto.assistant.ReqDto.*;
-import static com.develokit.maeum_ieum.dto.assistant.RespDto.*;
+import static com.develokit.maeum_ieum.dto.assistant.RespDto.VerifyAccessCodeRespDto;
 import static com.develokit.maeum_ieum.dto.elderly.RespDto.*;
-import static com.develokit.maeum_ieum.dto.emergencyRequest.ReqDto.*;
-import static com.develokit.maeum_ieum.dto.emergencyRequest.RespDto.*;
-import static com.develokit.maeum_ieum.dto.message.ReqDto.*;
-import static com.develokit.maeum_ieum.dto.openAi.audio.RespDto.*;
+import static com.develokit.maeum_ieum.dto.emergencyRequest.ReqDto.EmergencyRequestCreateReqDto;
+import static com.develokit.maeum_ieum.dto.emergencyRequest.RespDto.EmergencyRequestCreateRespDto;
+import static com.develokit.maeum_ieum.dto.message.ReqDto.CreateStreamMessageReqDto;
+import static com.develokit.maeum_ieum.dto.message.RespDto.CreateStreamMessageRespDto;
+import static com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.CreateAudioReqDto;
+import static com.develokit.maeum_ieum.dto.openAi.audio.RespDto.CreateAudioRespDto;
 
 @Tag(name = "노인 사용자 API", description = "노인 사용자가 호출하는 API 목록")
 public interface ElderlyControllerDocs {
@@ -70,7 +69,7 @@ public interface ElderlyControllerDocs {
 
     @Operation(summary = "채팅 (스트림 답변)", description = "텍스트 기반 채팅 시 요청. 스트림으로 메시지 반환")
     @ApiResponses( value = {
-            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CheckAssistantInfoRespDto.class), examples = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CreateStreamMessageRespDto.class), examples = {
                     @ExampleObject(
                             name = "isLast:false -> 응답 받아야 할 답변이 더 있는 상태",
                             value = "{\n  \"answer\": \"가\",\n  \"isLast\": false,\n  \"timeStamp\": null\n}",
@@ -82,10 +81,10 @@ public interface ElderlyControllerDocs {
                             summary = "답변 생성 완료"
                     )
             }, mediaType = "application/json")),
-            @ApiResponse(responseCode = "500", description = "OPENAI_SERVER_ERROR | INTERNAL_SERVER_ERROR", content = @Content(schema = @Schema(implementation = CheckAssistantInfoRespDto.class), mediaType = "application/json"))
+            @ApiResponse(responseCode = "500", description = "OPENAI_SERVER_ERROR | INTERNAL_SERVER_ERROR", content = @Content(schema = @Schema(implementation = CreateStreamMessageRespDto.class), mediaType = "application/json"))
 
     })
-    Flux<com.develokit.maeum_ieum.dto.message.RespDto.CreateStreamMessageRespDto> createStreamMessage(
+    Flux<CreateStreamMessageRespDto> createStreamMessage(
             @PathVariable(name = "elderlyId") Long elderlyId,
             @RequestBody @Valid CreateStreamMessageReqDto createStreamMessageReqDto,
             BindingResult bindingResult);
@@ -106,10 +105,10 @@ public interface ElderlyControllerDocs {
     @Operation(summary = "채팅(오디오 답변)", description = "음성 기반 채팅 시 요청")
     @ApiResponses( value = {
             @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CreateAudioRespDto.class), mediaType = "application/json")),
-            @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR(긴급 알림 요양사에게 전달 실패)", content = @Content(schema = @Schema(implementation = CreateAudioRespDto.class), mediaType = "application/json"))
+            @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR", content = @Content(schema = @Schema(implementation = CreateAudioRespDto.class), mediaType = "application/json"))
 
     })
     Mono<?> createVoiceMessage(@PathVariable(name = "elderlyId")Long elderlyId,
-                               @Valid @RequestBody com.develokit.maeum_ieum.dto.openAi.audio.ReqDto.CreateAudioReqDto createAudioReqDto,
+                               @Valid @RequestBody CreateAudioReqDto createAudioReqDto,
                                BindingResult bindingResult);
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/assistant/Assistant.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/assistant/Assistant.java
@@ -40,7 +40,7 @@ public class Assistant extends BaseEntity {
     @JoinColumn(name = "caregiver_id", nullable = false)
     private Caregiver caregiver;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "elderly_id")
     private Elderly elderly;
 

--- a/src/main/java/com/develokit/maeum_ieum/domain/report/HealthStatus.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/report/HealthStatus.java
@@ -1,0 +1,19 @@
+package com.develokit.maeum_ieum.domain.report;
+
+public enum HealthStatus {
+    VERY_POOR("정말 별로예요"),
+    POOR("별로예요"),
+    FAIR("그냥 그래요"),
+    GOOD("좋아요"),
+    EXCELLENT("아주 좋아요");
+
+    private final String description;
+
+    HealthStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/develokit/maeum_ieum/domain/report/Report.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/report/Report.java
@@ -5,6 +5,7 @@ import com.develokit.maeum_ieum.domain.base.BaseEntity;
 import com.develokit.maeum_ieum.domain.user.elderly.Elderly;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,18 +32,51 @@ public class Report extends BaseEntity {
     private LocalDateTime endDate;// 보고서 기록 종료 일
 
     @Column(length = 2048)
-    private String analysisResult; //분석 결과
+    private String quantitativeAnalysis; //정량적 분석 결과
 
+    @Column(length = 2048)
+    private String qualitativeAnalysis; //정성적 분석
+
+    @Enumerated(EnumType.STRING)
+    private HealthStatus healthStatus; //건강 상태 지표
+
+    @Column(length = 512)
     private String memo; //메모
 
+    @Enumerated(EnumType.STRING)
+    private ReportStatus reportStatus;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek reportDay;
+
+    @Builder
+    public Report(Elderly elderly, ReportType reportType, LocalDateTime startDate, LocalDateTime endDate, String quantitativeAnalysis, String qualitativeAnalysis, HealthStatus healthStatus, String memo, ReportStatus reportStatus, DayOfWeek reportDay) {
+        this.elderly = elderly;
+        this.reportType = reportType;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.quantitativeAnalysis = quantitativeAnalysis;
+        this.qualitativeAnalysis = qualitativeAnalysis;
+        this.healthStatus = healthStatus;
+        this.memo = memo;
+        this.reportStatus = reportStatus;
+        this.reportDay = reportDay;
+    }
+    public void modifyStartDateAndReportDay(LocalDateTime localDateTime, DayOfWeek dayOfWeek){
+        this.startDate = localDateTime;
+        this.reportDay = dayOfWeek;
+    }
+
+    public void updateReportStatus(ReportStatus reportStatus){
+        this.reportStatus = reportStatus;
+    }
+
+    public void updateEndDate(LocalDateTime localDateTime){
+        this.endDate = localDateTime;
+    }
     /*
-
-
-    보고서 지표들
-
-
-
-     */
+        보고서 지표들
+         */
     public Report(Elderly elderly, LocalDateTime startDate, LocalDateTime endDate, ReportType reportType){
         this.elderly = elderly;
         this.startDate = startDate;

--- a/src/main/java/com/develokit/maeum_ieum/domain/report/ReportRepository.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/report/ReportRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +16,10 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     @Query("select count(r) from Report r where r.elderly =: elderly and r.startDate = : startDate")
     int findByStartDate(@Param(value = "elderly")Elderly elderly, @Param(value = "startDate")LocalDateTime startDate);
+
+    @Query("select r from Report r where r.elderly = :elderly order by r.startDate desc limit 1")
+    Optional<Report> findLatestByElderly(@Param("Elderly")Elderly elderly );
+
+
+    List<Report> findByReportDayAndReportStatus(DayOfWeek reportDay, ReportStatus reportStatus);
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/report/ReportStatus.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/report/ReportStatus.java
@@ -1,0 +1,5 @@
+package com.develokit.maeum_ieum.domain.report;
+
+public enum ReportStatus {
+    PROCESSING, COMPLETED, PENDING, ERROR
+}

--- a/src/main/java/com/develokit/maeum_ieum/domain/user/caregiver/Caregiver.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/user/caregiver/Caregiver.java
@@ -23,6 +23,7 @@ import static com.develokit.maeum_ieum.service.CaregiverService.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @AllArgsConstructor
+@ToString
 public class Caregiver extends User {
 
     @Id
@@ -37,12 +38,15 @@ public class Caregiver extends User {
     private String password;
 
     @OneToMany(mappedBy = "caregiver")
+    @ToString.Exclude
     private List<Assistant> assistantList = new ArrayList<>();
 
     @OneToMany(mappedBy = "caregiver")
+    @ToString.Exclude
     private List<Elderly> elderlyList = new ArrayList<>();
 
     @OneToMany(mappedBy = "caregiver") //긴급 알림 리스트
+    @ToString.Exclude
     private List<EmergencyRequest> emergencyRequestList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/develokit/maeum_ieum/service/ElderlyService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/ElderlyService.java
@@ -29,8 +29,10 @@ import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Flux;
 
 import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -151,6 +153,14 @@ public class ElderlyService {
         if(!assistantPS.hasThread()){ //스레드 없음
             ThreadRespDto threadRespDto = openAiService.createThread();
             assistantPS.attachThread(threadRespDto.getId());
+        }
+        else{ //스레드가 있다면
+            LocalDateTime lastChatTime = elderlyPS.getLastChatTime();
+            //마지막 접근일로부터 30일이 지났는지 검증 -> 지났다면 새로운 스레드 생성
+            if(ChronoUnit.DAYS.between(lastChatTime, LocalDateTime.now()) >= 30){
+                ThreadRespDto threadRespDto = openAiService.createThread();
+                assistantPS.attachThread(threadRespDto.getId());
+            }
         }
 
         return new CheckAssistantInfoRespDto(assistantPS);

--- a/src/main/java/com/develokit/maeum_ieum/service/ReportService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/ReportService.java
@@ -30,76 +30,11 @@ public class ReportService {
     private final ElderlyRepository elderlyRepository;
     private final Logger log = LoggerFactory.getLogger(ReportService.class);
 
-    @Scheduled(cron = "0 0 0 * * *") //매일 해당 요일에 보고서 생성을 지정한 사용자의 주간 보고서 생성
-    @Transactional
-    public void generateWeeklyReport(){
-        //해당 요일에 발행되도록 지정된 대기 상태의 보고서들 가져오기
-        LocalDateTime today = LocalDateTime.now();
-        List<Report> reportsToGenerate = reportRepository.findByReportDayAndReportStatus(today.getDayOfWeek(), ReportStatus.PENDING);
-
-        for (Report report : reportsToGenerate) {
-            //보고서 생성 시작일로부터 일주일이 됐다면
-            if(ChronoUnit.DAYS.between(report.getStartDate(), today) == 7){
-                try {
-                    //보고서 상태 변경: 대기 -> 분석 진행 중
-                    report.updateReportStatus(ReportStatus.PROCESSING);
-
-                    //분석 시작
-                    generateReportContent(report);
-
-                    //보고서 상태 변경: 분석 진행 중 -> 분석 완료
-                    report.updateReportStatus(ReportStatus.COMPLETED);
-                    report.updateEndDate(today);
-                }catch (Exception e){
-                    log.error("보고서 분석 중 오류 발생: {elderlyId : "+report.getElderly().getId() + "} " + e);
-                    report.updateReportStatus(ReportStatus.ERROR);
-                }
-                // 각 반복마다 변경사항을 명시적으로 저장 ->  대량 처리 시 메모리 관리에 도움
-                reportRepository.save(report);
-            }
-        }
-
-
-
-        LocalDateTime[] weekStartAndEnd = CustomUtil.getWeekStartAndEnd(LocalDateTime.now());
-        LocalDateTime startDate = weekStartAndEnd[0];
-        LocalDateTime endDate = weekStartAndEnd[1];
-
-        //해당 요일에 보고서 생성되도록 지정된 노인 사용자 찾기
-        List<Elderly> elderlyList = elderlyRepository.findByReportDay(today);
-        List<Report> reportList = new ArrayList<>();
-
-        //보고서 생성 안됐는지 검증하고 보고서 생성하기
-        for (Elderly elderly : elderlyList) {
-            if(!reportExistsForWeek(elderly, startDate)){
-                reportList.add(new Report(elderly, startDate, endDate, ReportType.WEEKLY));
-            }
-        }
-        //생성된 보고서 저장
-        if(!reportList.isEmpty()){
-            reportRepository.saveAll(reportList);
-            log.debug(today+" 주간 보고서 생성 완료");
-        }
-    }
-
-    //해당 주의 보고서가 이미 존재하면 true 반환
-    private boolean reportExistsForWeek(Elderly elderly, LocalDateTime startDate){
-        return reportRepository.findByStartDate(elderly, startDate) > 0;
-    }
-
     //지표에 따른 보고서 생성하기
-    private void generateReportContent(Report report){
+    public void generateReportContent(Report report){
 
 
     }
-
-
-
-    //보고서 지정된 요일에 주간 보고서 자동 생성 -> 그 요일이 되는 자정에 생성하도록
-
-
-
-
 
 
     //보고서 지정된 요일에 월간 보고서 자동 생성

--- a/src/test/java/com/develokit/maeum_ieum/config/batch/ReportJobConfigTest.java
+++ b/src/test/java/com/develokit/maeum_ieum/config/batch/ReportJobConfigTest.java
@@ -1,0 +1,50 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBatchTest
+@SpringBootTest
+class ReportJobConfigTest {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+//    @Autowired
+//    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private Job weeklyReportGenerationJob;
+
+    @Autowired
+    private Step reportGenerationStep;
+
+    @Test
+    void testReportGenerationJob() throws Exception {
+        // Job 실행
+        JobExecution jobExecution = jobLauncher.run(weeklyReportGenerationJob, new JobParameters());
+
+        // 결과 검증
+        assertEquals("COMPLETED", jobExecution.getStatus().toString());
+    }
+
+//    @Test
+//    void testReportGenerationStep() throws Exception {
+//        // Step 실행
+//        JobExecution jobExecution = jobLauncherTestUtils.launchStep("reportGenerationStep");
+//
+//        // Step 결과 검증
+//        assertEquals("COMPLETED", jobExecution.getStatus().toString());
+//    }
+
+
+}

--- a/src/test/java/com/develokit/maeum_ieum/config/batch/ReportProcessorTest.java
+++ b/src/test/java/com/develokit/maeum_ieum/config/batch/ReportProcessorTest.java
@@ -1,0 +1,83 @@
+package com.develokit.maeum_ieum.config.batch;
+
+import com.develokit.maeum_ieum.domain.report.Report;
+import com.develokit.maeum_ieum.domain.report.ReportStatus;
+import com.develokit.maeum_ieum.domain.user.elderly.Elderly;
+import com.develokit.maeum_ieum.ex.CustomApiException;
+import com.develokit.maeum_ieum.service.ReportService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportProcessorTest {
+
+    @InjectMocks
+    private ReportProcessor reportProcessor;
+
+    @Mock
+    private ReportService reportService;
+
+    @Mock
+    private Logger log;
+
+    @Test
+    void testProcess_Successful() throws Exception {
+        // given
+        Report report = mock(Report.class);
+        Elderly elderly = mock(Elderly.class);
+
+        Report report2 = mock(Report.class);
+        Elderly elderly2 = mock(Elderly.class);
+
+        when(elderly.getId()).thenReturn(1L);
+        when(report.getElderly()).thenReturn(elderly);
+
+        when(elderly2.getId()).thenReturn(2L);
+        when(report2.getElderly()).thenReturn(elderly2);
+
+        // when
+        ReportProcessor.ReportProcessResult result = reportProcessor.process(report);
+        ReportProcessor.ReportProcessResult result2 = reportProcessor.process(report2);
+
+        // then
+        verify(report, times(1)).updateReportStatus(ReportStatus.PROCESSING);
+        verify(reportService, times(1)).generateReportContent(report);
+        verify(report, times(1)).updateReportStatus(ReportStatus.COMPLETED);
+        assertNotNull(result.getCompletedReport());
+        assertNotNull(result.getNextReport());
+
+        verify(report2, times(1)).updateReportStatus(ReportStatus.PROCESSING);
+        verify(reportService, times(1)).generateReportContent(report2);
+        verify(report2, times(1)).updateReportStatus(ReportStatus.COMPLETED);
+        assertNotNull(result2.getCompletedReport());
+        assertNotNull(result2.getNextReport());
+    }
+
+    @Test
+    void testProcess_WithError() throws Exception {
+        // given
+        Report report = mock(Report.class);
+        Elderly elderly = mock(Elderly.class);
+
+        when(elderly.getId()).thenReturn(1L);
+        when(report.getElderly()).thenReturn(elderly);
+        doThrow(new RuntimeException("Some error")).when(reportService).generateReportContent(report);
+
+        // when
+        Exception exception = assertThrows(CustomApiException.class, () -> reportProcessor.process(report));
+
+        // then
+        verify(report, times(1)).updateReportStatus(ReportStatus.PROCESSING);
+        verify(reportService, times(1)).generateReportContent(report);
+        verify(report, times(1)).updateReportStatus(ReportStatus.ERROR);
+        assertEquals("보고서 배치 처리 중 오류 발생", exception.getMessage());
+    }
+
+}

--- a/src/test/java/com/develokit/maeum_ieum/service/WebSocketServiceTest.java
+++ b/src/test/java/com/develokit/maeum_ieum/service/WebSocketServiceTest.java
@@ -15,6 +15,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.eq;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,21 +42,44 @@ class WebSocketServiceTest {
     void 요양사에게_긴급알림_전송되는지_테스트() throws Exception{
         //given
         Long caregiverId = 98L;
-        String expectedMessage = "토쿠노으로부터 긴급알림이 왔습니다";
+        Long elderlyId = 1L;
+        String elderlyName = "토쿠노";
+        String id = UUID.randomUUID().toString();
+        String message = "토쿠노 어르신으로부터 긴급알림이 왔습니다";
+        LocalDateTime today = LocalDateTime.now();
         String expectedDestination = "/topic/emergencyRequests/" + caregiverId;
 
-        Caregiver caregiver = mock(Caregiver.class);
-        when(caregiver.getId()).thenReturn(caregiverId);
 
         EmergencyRequest emergencyRequest = mock(EmergencyRequest.class);
-        when(emergencyRequest.getMessage()).thenReturn(expectedMessage);
+        Caregiver caregiver = mock(Caregiver.class);
+        Elderly elderly = mock(Elderly.class);
+
+        when(emergencyRequest.getElderly()).thenReturn(elderly);
+        when(elderly.getId()).thenReturn(elderlyId);
+        when(caregiver.getId()).thenReturn(caregiverId);
+        when(elderly.getName()).thenReturn(elderlyName);
+        when(emergencyRequest.getCreatedDate()).thenReturn(today);
+        when(emergencyRequest.getEmergencyType()).thenReturn(EmergencyType.CAREGIVER_NOTIFY);
+        when(emergencyRequest.getMessage()).thenReturn(message);
+
+
+        Map<String, Object> alertMessage = new HashMap<>();
+        alertMessage.put("id", id);
+        alertMessage.put("elderlyId", elderlyId);
+        alertMessage.put("elderlyName", elderlyName);
+        alertMessage.put("emergencyType", EmergencyType.CAREGIVER_NOTIFY.toString());
+        alertMessage.put("message", message);
+        alertMessage.put("timestamp", today);
+        alertMessage.put("caregiverId", caregiverId);
+
 
         // when
         boolean result = webSocketService.sendEmergencyRequestToCaregiver(caregiver, emergencyRequest);
 
         // then
         assertTrue(result);
-        verify(messagingTemplate).convertAndSend(eq(expectedDestination), eq(expectedMessage));
+        System.out.println("messagingTemplate = " + messagingTemplate);
+        verify(messagingTemplate).convertAndSend(eq(expectedDestination), eq(alertMessage));
     }
 
 }


### PR DESCRIPTION
### 주간 보고서
- reportDay 등록 -> 등록 일자를 startDate으로 갖는 빈 Report 생성
- 스케줄링으로 현재 일자가 startDate으로부터 일주일 이상(일주일으로 추후 조정)되는 Report를 찾고
- 청크 수(100)만큼 끌고 온 뒤에
- 추후 정해지는 보고서 지표에 따른 분석 로직 수행
- 보고서 분석 반영되면 endDate을 분석 종료 시간으로 설정
- endDate을 다음 Report의 startDate으로 갖는 빈 Report 생성
- 만약 reportDay 수정이 발생하면 startDate을 reportDaty 수정이 일어난 시간으로 변경

### 스레드
- 스레드 마지막 접근일로부터 30일 지나면 새 스레드 할당한 뒤 스레드 생성 시간 업데이트
