### PR TITLE
WebFlux 시큐리티 설정

### DIFF
--- a/src/main/java/com/develokit/maeum_ieum/config/SecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                 .exceptionHandling(handler -> {
                     handler
                     .authenticationEntryPoint((request, response, authException) -> {
+                        log.error("인증되지 않은 접근 발생: {}, {}", request,response);
                         ObjectMapper om = new ObjectMapper();
                         ApiResult<?> responseDto = ApiUtil.error("인증되지 않은 접근입니다", HttpStatus.UNAUTHORIZED.value());
                         String responseBody = CustomUtil.convertToJson(responseDto);

--- a/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtAuthorizationFilter.java
@@ -1,12 +1,11 @@
 package com.develokit.maeum_ieum.config.jwt;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.exceptions.SignatureGenerationException;
-import com.auth0.jwt.exceptions.SignatureVerificationException;
-import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.exceptions.*;
 import com.develokit.maeum_ieum.config.loginUser.LoginUser;
 import com.develokit.maeum_ieum.ex.CustomApiException;
 import com.develokit.maeum_ieum.util.ApiUtil;
+import com.develokit.maeum_ieum.util.CustomUtil;
+import com.develokit.maeum_ieum.util.api.ApiResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.util.concurrent.BlockingOperationException;
 import jakarta.servlet.FilterChain;
@@ -52,76 +51,43 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                 return;
             }
 
-            String token = header.replace(JwtVo.TOKEN_PREFIX, "");
-            logger.debug("디버그 : JWT 토큰 확인됨. URI: {}", request.getRequestURI());
+            try {
+                String token = header.replace(JwtVo.TOKEN_PREFIX, "");
+                logger.debug("디버그 : JWT 토큰 확인됨. URI: {}", request.getRequestURI());
 
-            // 토큰 검증
-            LoginUser loginUser = JwtProvider.verify(token);
+                // 토큰 검증
+                LoginUser loginUser = JwtProvider.verify(token);
 
-            loginUser.getAuthorities().forEach(grantedAuthority ->
-                    logger.debug("디버그 : 부여된 권한: {}", grantedAuthority.getAuthority()));
+                loginUser.getAuthorities().forEach(grantedAuthority ->
+                        logger.debug("디버그 : 부여된 권한: {}", grantedAuthority.getAuthority()));
 
-            // 임시 세션 생성
-            Authentication authentication = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
+                // 임시 세션 생성
+                Authentication authentication = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
 
-            logger.debug("인증 정보 설정 완료. 사용자: {}", loginUser.getUsername());
+                logger.debug("인증 정보 설정 완료. 사용자: {}", loginUser.getUsername());
 
-            // 로그인
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                // 로그인
+                SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            chain.doFilter(request, response);
+                chain.doFilter(request, response);
+            } catch (TokenExpiredException e) {
+                setErrorResponse(HttpStatus.UNAUTHORIZED, response,  "토큰이 만료되었습니다");
+            } catch (JWTDecodeException e) {
+                setErrorResponse(HttpStatus.UNAUTHORIZED, response, "유효하지 않은 JWT 형식입니다");
+            } catch (SignatureVerificationException e) {
+                setErrorResponse(HttpStatus.UNAUTHORIZED, response, "유효하지 않은 토큰 서명입니다");
+            } catch (JWTVerificationException e) {
+                setErrorResponse(HttpStatus.UNAUTHORIZED, response, "유효하지 않은 토큰입니다");
+            } catch (Exception e) {
+                logger.error("예기치 않은 오류 발생: {}", e.getMessage(), e);
+                setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, "서버 내부 오류가 발생했습니다");
+            }
+    }
+    private void setErrorResponse(HttpStatus status, HttpServletResponse response, String message) throws IOException {
+        ApiResult<Object> jwtExceptionResponse = ApiUtil.error(message, status.value());
+        response.setStatus(status.value());
+        response.setContentType("application/json; charset=UTF-8");
+        response.getWriter().write(CustomUtil.convertToJson(jwtExceptionResponse));
     }
 
-
-    //    //헤더 검증
-    //    private boolean isHeaderVerify(HttpServletRequest request){
-    //        try {
-    //            //HandlerMethod handlerMethod = (HandlerMethod) handlerMapping.getHandler(request).getHandler();
-    //
-    //            HandlerExecutionChain handlerChain = handlerMapping.getHandler(request);
-    //            System.out.println(handlerChain.toString());
-    //            if (handlerChain == null) {
-    //                throw new CustomApiException("요청된 URI에 대한 핸들러가 없습니다", HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND);
-    //            }
-    //            HandlerMethod handlerMethod = (HandlerMethod) handlerChain.getHandler();
-    //            if (handlerMethod.getMethodAnnotation(RequireAuth.class) != null) {
-    //                logger.debug("RequireAuth API 헤더 검증 중");
-    //                String header = request.getHeader(JwtVo.HEADER);
-    //                if (header == null || !header.startsWith(JwtVo.TOKEN_PREFIX)) {
-    //                    throw new CustomApiException("Authorization 헤더 재확인 바람", HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED);
-    //                } else return true; //헤더 검사 통과하면 필터 내에서 토큰 검증
-    //            }
-    //            return false;
-    //        }catch(CustomApiException e){
-    //            throw e;
-    //        } catch (Exception e){
-    //            if (request.getRequestURI().contains("swagger-ui")) //스웨거 접근 허용
-    //                return false;
-    //            logger.error(e.getMessage());
-    //            throw new CustomApiException("헤더 검증 과정에서 에러 발생",HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR);
-    //        }
-    //    }
-    //
-    //    @Override
-    //    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException{
-    //        if(isHeaderVerify(request)){
-    //            //토큰 있음 -> 임시 세션 생성
-    //            String token = request.getHeader(JwtVo.HEADER).replace(JwtVo.TOKEN_PREFIX, "");//Bearer 제거
-    //            logger.debug("디버그 : 토큰이 존재함");
-    //
-    //            //토큰 검증
-    //            LoginUser loginUser = JwtProvider.verify(token);
-    //
-    //            loginUser.getAuthorities().stream().forEach(grantedAuthority -> System.out.println("grantedAuthority.getAuthority().toString() = " + grantedAuthority.getAuthority().toString()));
-    //            //임시 세션
-    //            Authentication authentication = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
-    //
-    //            logger.debug("임시 세션 생성");
-    //
-    //            //로그인
-    //            SecurityContextHolder.getContext().setAuthentication(authentication);
-    //        }
-    //        //다시 체인 타기
-    //        chain.doFilter(request, response);
-    //    }
 }

--- a/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtAuthorizationFilter.java
@@ -53,18 +53,18 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             }
 
             String token = header.replace(JwtVo.TOKEN_PREFIX, "");
-            logger.debug("디버그 : 토큰이 존재함");
+            logger.debug("디버그 : JWT 토큰 확인됨. URI: {}", request.getRequestURI());
 
             // 토큰 검증
             LoginUser loginUser = JwtProvider.verify(token);
 
             loginUser.getAuthorities().forEach(grantedAuthority ->
-                    logger.debug("grantedAuthority.getAuthority().toString() = " + grantedAuthority.getAuthority().toString()));
+                    logger.debug("디버그 : 부여된 권한: {}", grantedAuthority.getAuthority()));
 
             // 임시 세션 생성
             Authentication authentication = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
 
-            logger.debug("임시 세션 생성");
+            logger.debug("인증 정보 설정 완료. 사용자: {}", loginUser.getUsername());
 
             // 로그인
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtExceptionFilter.java
@@ -10,6 +10,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,25 +20,26 @@ import java.io.IOException;
 
 @Component
 public class JwtExceptionFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(JwtExceptionFilter.class);
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
         } catch (CustomApiException e) {
-            logger.error("CustomApiException: ", e);
+            log.error("CustomApiException: URI = {}, 메시지 = {} ",request.getRequestURI(), e.getMessage(), e);
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
         } catch (TokenExpiredException e) {
-            logger.error("TokenExpiredException: ", e);
+            log.error("TokenExpiredException: URI = {}, 메시지 = {}", request.getRequestURI(), e.getMessage(), e);
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, "토큰이 만료되었습니다");
         } catch (SignatureVerificationException e) {
-            logger.error("SignatureVerificationException: ", e);
+            log.error("SignatureVerificationException: URI = {}, 메시지 = {}", request.getRequestURI(), e.getMessage(), e);
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, "유효하지 않은 토큰 서명입니다");
         } catch (JWTVerificationException e) {
-            logger.error("JWTVerificationException: ", e);
+            log.error("JWTVerificationException: URI = {}, 메시지 = {}", request.getRequestURI(), e.getMessage(), e);
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, "유효하지 않은 토큰입니다");
         } catch (Exception e) {
-            logger.error("Unexpected Exception: ", e);
+            log.error("Unexpected Exception: URI = {}, 메시지 = {}", request.getRequestURI(), e.getMessage(), e);
             setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, "서버 내부 오류가 발생했습니다");
         }
     }

--- a/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtProvider.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/jwt/JwtProvider.java
@@ -2,6 +2,7 @@ package com.develokit.maeum_ieum.config.jwt;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
@@ -39,13 +40,17 @@ public class JwtProvider {
             decodedJWT = JWT.require(Algorithm.HMAC256(JwtVo.SECRET)).build().verify(token);
         } catch (TokenExpiredException e){
             logger.error("토큰이 만료되어 더 이상 유효하지 않습니다", e);
-            throw new CustomApiException("토큰 기간 만료", HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED);
+            throw e;
         } catch(SignatureVerificationException e){
             logger.error("유효하지 않은 토큰 서명입니다", e);
-            throw new CustomApiException("유효하지 않은 토큰 서명", HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED);
-        } catch(JWTVerificationException e){
+            throw e;
+        } catch (JWTDecodeException e) {
+            logger.error("유효하지 않은 JWT 형식입니다", e);
+            throw e;
+        }
+        catch(JWTVerificationException e){
             logger.error("JWT 검증 중 오류가 발생했습니다", e);
-            throw new CustomApiException("유효하지 않은 토큰",HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED);
+            throw e;
         }
 
         String username =

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/GptFeignClient.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/GptFeignClient.java
@@ -1,2 +1,17 @@
-package com.develokit.maeum_ieum.config.openAI.header;public interface GptFeignClient {
+package com.develokit.maeum_ieum.config.openAI;
+
+import com.develokit.maeum_ieum.config.openAI.header.FeignHeaderConfig;
+import com.develokit.maeum_ieum.dto.openAi.gpt.ReqDto;
+import com.develokit.maeum_ieum.dto.openAi.gpt.RespDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import static com.develokit.maeum_ieum.dto.openAi.gpt.ReqDto.*;
+import static com.develokit.maeum_ieum.dto.openAi.gpt.RespDto.*;
+
+@FeignClient(name = "GptFeignClient", url = "https://api.openai.com/v1", configuration = FeignHeaderConfig.class)
+public interface GptFeignClient {
+
+    @PostMapping("/chat/completions")
+    CreateGptMessageRespDto createGptMessage(CreateGptMessageReqDto createGptMessageReqDto);
 }

--- a/src/main/java/com/develokit/maeum_ieum/config/openAI/GptFeignClient.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/openAI/GptFeignClient.java
@@ -1,0 +1,2 @@
+package com.develokit.maeum_ieum.config.openAI.header;public interface GptFeignClient {
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/security/SecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/security/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.develokit.maeum_ieum.config;
 import com.develokit.maeum_ieum.config.jwt.JwtAuthenticationFilter;
 import com.develokit.maeum_ieum.config.jwt.JwtAuthorizationFilter;
 import com.develokit.maeum_ieum.config.jwt.JwtExceptionFilter;
+import com.develokit.maeum_ieum.config.jwt.JwtProvider;
+import com.develokit.maeum_ieum.config.loginUser.LoginUser;
 import com.develokit.maeum_ieum.domain.user.Role;
 import com.develokit.maeum_ieum.util.ApiUtil;
 import com.develokit.maeum_ieum.util.CustomUtil;
@@ -15,20 +17,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.server.WebFilter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import reactor.core.publisher.Mono;
 
 import java.security.SecureRandom;
 import java.util.Collections;
@@ -57,11 +69,43 @@ public class SecurityConfig {
         public void configure(HttpSecurity builder) throws Exception {
             AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
             builder.addFilterBefore(jwtExceptionFilter, JwtAuthorizationFilter.class); //토큰 검증 전에 에러 잡기 위한 필터
+            builder.addFilterBefore(new JwtAuthorizationFilter(authenticationManager, handlerMapping), UsernamePasswordAuthenticationFilter.class); //인가 필터
             builder.addFilter(new JwtAuthenticationFilter(authenticationManager)); //jwt 인증 필터
-            builder.addFilter(new JwtAuthorizationFilter(authenticationManager, handlerMapping)); //인가 필터
             super.configure(builder);
         }
     }
+
+    // WebFlux 스타일 메서드를 위한 추가 설정
+//    @Bean
+//    public WebFilter webFluxSecurityFilter() {
+//        return (exchange, chain) -> {
+//            ServerHttpRequest request = exchange.getRequest();
+//            if (request.getPath().value().contains("/assistants/rules/autocomplete")) {
+//                String token = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+//                if (token != null && token.startsWith("Bearer ")) {
+//                    token = token.substring(7);
+//                    try {
+//                        LoginUser loginUser = JwtProvider.verify(token);
+//                        UsernamePasswordAuthenticationToken auth =
+//                                new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
+//
+//                        return chain.filter(exchange)
+//                                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(auth));
+//                    } catch (Exception e) {
+//                        return onError(exchange, "Invalid token", HttpStatus.UNAUTHORIZED);
+//                    }
+//                }
+//                return onError(exchange, "No token found", HttpStatus.UNAUTHORIZED);
+//            }
+//            return chain.filter(exchange);
+//        };
+//    }
+//
+//    private Mono<Void> onError(ServerWebExchange exchange, String err, HttpStatus httpStatus) {
+//        ServerHttpResponse response = exchange.getResponse();
+//        response.setStatusCode(httpStatus);
+//        return response.setComplete();
+//    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
@@ -85,7 +129,7 @@ public class SecurityConfig {
                 .exceptionHandling(handler -> {
                     handler
                     .authenticationEntryPoint((request, response, authException) -> {
-                        log.error("인증되지 않은 접근 발생: {}, {}", request,response);
+                        log.error("인증되지 않은 접근 발생: URI: {}, Request: {}, Response: {}", request.getRequestURI(), request, response);
                         ObjectMapper om = new ObjectMapper();
                         ApiResult<?> responseDto = ApiUtil.error("인증되지 않은 접근입니다", HttpStatus.UNAUTHORIZED.value());
                         String responseBody = CustomUtil.convertToJson(responseDto);

--- a/src/main/java/com/develokit/maeum_ieum/config/security/SecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.develokit.maeum_ieum.config;
+package com.develokit.maeum_ieum.config.security;
 
 import com.develokit.maeum_ieum.config.jwt.JwtAuthenticationFilter;
 import com.develokit.maeum_ieum.config.jwt.JwtAuthorizationFilter;
@@ -15,8 +15,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -48,6 +50,8 @@ import java.util.Collections;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@Order(2)
 public class SecurityConfig {
 
     private final Logger log = LoggerFactory.getLogger((getClass()));
@@ -74,38 +78,6 @@ public class SecurityConfig {
             super.configure(builder);
         }
     }
-
-    // WebFlux 스타일 메서드를 위한 추가 설정
-//    @Bean
-//    public WebFilter webFluxSecurityFilter() {
-//        return (exchange, chain) -> {
-//            ServerHttpRequest request = exchange.getRequest();
-//            if (request.getPath().value().contains("/assistants/rules/autocomplete")) {
-//                String token = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-//                if (token != null && token.startsWith("Bearer ")) {
-//                    token = token.substring(7);
-//                    try {
-//                        LoginUser loginUser = JwtProvider.verify(token);
-//                        UsernamePasswordAuthenticationToken auth =
-//                                new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
-//
-//                        return chain.filter(exchange)
-//                                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(auth));
-//                    } catch (Exception e) {
-//                        return onError(exchange, "Invalid token", HttpStatus.UNAUTHORIZED);
-//                    }
-//                }
-//                return onError(exchange, "No token found", HttpStatus.UNAUTHORIZED);
-//            }
-//            return chain.filter(exchange);
-//        };
-//    }
-//
-//    private Mono<Void> onError(ServerWebExchange exchange, String err, HttpStatus httpStatus) {
-//        ServerHttpResponse response = exchange.getResponse();
-//        response.setStatusCode(httpStatus);
-//        return response.setComplete();
-//    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{

--- a/src/main/java/com/develokit/maeum_ieum/config/security/WebConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/security/WebConfig.java
@@ -1,0 +1,2 @@
+package com.develokit.maeum_ieum.config.security;public class WebCOnfig {
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/security/WebConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/security/WebConfig.java
@@ -1,2 +1,49 @@
-package com.develokit.maeum_ieum.config.security;public class WebCOnfig {
+package com.develokit.maeum_ieum.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.DispatcherHandler;
+import org.springframework.web.reactive.function.server.*;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.path;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public DispatcherHandler webHandler() {
+        return new DispatcherHandler();
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> reactiveRoutes(DispatcherHandler dispatcherHandler) {
+        return RouterFunctions.route()
+                .path("/reactive", builder -> builder
+                        .nest(RequestPredicates.path("/**"), nestedBuilder -> nestedBuilder
+                                .GET("/**", request -> handleRequest(request, dispatcherHandler))
+                                .POST("/**", request -> handleRequest(request, dispatcherHandler))
+                                .PUT("/**", request -> handleRequest(request, dispatcherHandler))
+                                .DELETE("/**", request -> handleRequest(request, dispatcherHandler))
+                        )
+                )
+                .build();
+    }
+
+    private Mono<ServerResponse> handleRequest(ServerRequest request, DispatcherHandler dispatcherHandler) {
+        return Mono.defer(() -> {
+            // 현재 request의 exchange 가져오기
+            ServerWebExchange exchange = request.exchange();
+
+            return dispatcherHandler.handle(exchange)
+                    .then(ServerResponse.ok().build())
+                    .onErrorResume(e -> {
+                        return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).bodyValue(e.getMessage());
+                    });
+        });
+    }
 }

--- a/src/main/java/com/develokit/maeum_ieum/config/security/WebFluxSecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/security/WebFluxSecurityConfig.java
@@ -1,0 +1,2 @@
+package com.develokit.maeum_ieum.config.security;public class WebFluxSecurityConfig {
+}

--- a/src/main/java/com/develokit/maeum_ieum/config/security/WebFluxSecurityConfig.java
+++ b/src/main/java/com/develokit/maeum_ieum/config/security/WebFluxSecurityConfig.java
@@ -1,2 +1,70 @@
-package com.develokit.maeum_ieum.config.security;public class WebFluxSecurityConfig {
+package com.develokit.maeum_ieum.config.security;
+
+import com.develokit.maeum_ieum.config.jwt.JwtProvider;
+import com.develokit.maeum_ieum.config.loginUser.LoginUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
+import org.springframework.web.server.WebFilter;
+
+@Configuration
+@EnableWebFluxSecurity
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE) //WebFlux 환경에서 실행될 때만 이 설정이 활성화
+@Order(1)  // 이 설정이 기존 MVC 보안 설정보다 먼저 적용되도록
+public class WebFluxSecurityConfig {
+
+    private final static Logger log = LoggerFactory.getLogger(WebFluxSecurityConfig.class);
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        return http
+                .securityMatcher(new PathPatternParserServerWebExchangeMatcher("/reactive/**"))
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/reactive/**").authenticated()
+                        .anyExchange().authenticated()
+                )
+                .addFilterBefore(webFluxJwtAuthenticationFilter(), SecurityWebFiltersOrder.AUTHORIZATION) // 필터 등록
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .build();
+    }
+
+    @Bean
+    public WebFilter webFluxJwtAuthenticationFilter() {
+        return (exchange, chain) -> {
+            String path = exchange.getRequest().getPath().value();
+            log.debug("WebFlux Filter: 처리 경로: {}", path); // 추가 로그
+
+            if (path.contains("/assistants/rules/autocomplete")) {
+                String token = exchange.getRequest().getHeaders().getFirst("Authorization");
+                if (token != null && token.startsWith("Bearer ")) {
+                    token = token.substring(7);
+                    try {
+                        LoginUser loginUser = JwtProvider.verify(token);
+                        return chain.filter(exchange)
+                                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(
+                                        new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities())
+                                ));
+                    } catch (Exception e) {
+                        exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                        return exchange.getResponse().setComplete();
+                    }
+                }
+                exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                return exchange.getResponse().setComplete();
+            }
+            return chain.filter(exchange);
+        };
+    }
 }

--- a/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverController.java
@@ -2,6 +2,7 @@ package com.develokit.maeum_ieum.controller.caregiver;
 
 import com.develokit.maeum_ieum.config.loginUser.LoginUser;
 import com.develokit.maeum_ieum.dto.assistant.ReqDto.CreateAssistantReqDto;
+import com.develokit.maeum_ieum.dto.assistant.RespDto;
 import com.develokit.maeum_ieum.dto.elderly.ReqDto.ElderlyCreateReqDto;
 import com.develokit.maeum_ieum.service.AssistantService;
 import com.develokit.maeum_ieum.service.CaregiverService;
@@ -9,6 +10,7 @@ import com.develokit.maeum_ieum.service.ElderlyService;
 import com.develokit.maeum_ieum.service.EmergencyRequestService;
 import com.develokit.maeum_ieum.service.report.ReportService;
 import com.develokit.maeum_ieum.util.ApiUtil;
+import com.develokit.maeum_ieum.util.api.ApiResult;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,13 +19,18 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Mono;
 
 import static com.develokit.maeum_ieum.dto.assistant.ReqDto.*;
+import static com.develokit.maeum_ieum.dto.assistant.RespDto.*;
 import static com.develokit.maeum_ieum.dto.caregiver.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.elderly.ReqDto.*;
 
@@ -142,20 +149,87 @@ public class CaregiverController implements CaregiverControllerDocs {
     }
 
     //노인 필수 규칙 자동 완성
-
     @PostMapping("/elderlys/{elderlyId}/assistants/rules/autocomplete")
-    public Mono<ResponseEntity<?>> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
-                                                           @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
-                                                           BindingResult bindingResult,
-                                                           @AuthenticationPrincipal LoginUser loginUser){
-        return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
-                .map(assistantMandatoryRuleRespDto -> {
-                    log.debug("노인 필수 규칙 자동 생성 완료. 응답: {}", assistantMandatoryRuleRespDto);
-                    return ResponseEntity
-                            .status(HttpStatus.CREATED)
-                            .body(ApiUtil.success(assistantMandatoryRuleRespDto));
-                });
+    public ResponseEntity<?> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
+                                                                                                  @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
+                                                                                                  BindingResult bindingResult,
+                                                                                                  @AuthenticationPrincipal LoginUser loginUser) {
+
+        return new ResponseEntity<>(ApiUtil.success(caregiverService.createAutoMandatoryRuleWithFeign(assistantMandatoryRuleReqDto)), HttpStatus.CREATED);
     }
+
+
+
+//    @PostMapping("/elderlys/{elderlyId}/assistants/rules/autocomplete")
+//    public Mono<ResponseEntity<ApiResult<AssistantMandatoryRuleRespDto>>> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
+//                                                                                                  @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
+//                                                                                                  BindingResult bindingResult,
+//                                                                                                  @AuthenticationPrincipal LoginUser loginUser){
+//
+//        //다섯 번쨰 시도 코드
+//        return ReactiveSecurityContextHolder.getContext()
+//                .flatMap(securityContext -> {
+//                    log.debug("Security Context: {}", securityContext.getAuthentication());
+//                    return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
+//                            .map(assistantMandatoryRuleRespDto -> {
+//                                log.debug("노인 필수 규칙 자동 생성 완료");
+//                                return ResponseEntity.status(HttpStatus.CREATED)
+//                                        .body(ApiUtil.success(assistantMandatoryRuleRespDto));
+//                            });
+//                })
+//                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(SecurityContextHolder.getContext())));
+
+        //네 번째 시도 코드
+//        SecurityContext context = SecurityContextHolder.getContext();
+//
+//        log.debug("노인 필수 규칙 자동 완성 컨트롤러에서의 인증 정보: {}", context.getAuthentication());
+//
+//        return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
+//                .map(assistantMandatoryRuleRespDto -> {
+//                    log.debug("노인 필수 규칙 자동 생성 완료");
+//                    return ResponseEntity.status(HttpStatus.CREATED)
+//                            .body(ApiUtil.success(assistantMandatoryRuleRespDto));
+//                })
+//                // Ensure the context is set properly for the entire Mono pipeline
+//                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(context)));
+
+
+        //세 번째 시도 코드
+//        return ReactiveSecurityContextHolder.getContext()
+//                .flatMap(securityContext -> {
+//                    log.debug("노인 필수 규칙 자동 완성 컨트롤러에서의 인증 정보: {}", loginUser);
+//                    return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto);
+//                })
+//                .map(assistantMandatoryRuleRespDto -> {
+//                    log.debug("노인 필수 규칙 자동 생성 완료");
+//                    return new ResponseEntity<>(ApiUtil.success(assistantMandatoryRuleRespDto), HttpStatus.CREATED);
+//                })
+//                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(
+//                        SecurityContextHolder.getContext().getAuthentication()
+//                ));
+
+
+
+        //두번 째 시도 코드
+//        return Mono.just(context)
+//                .flatMap(securityContext ->
+//                        caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
+//                )
+//                .map(assistantMandatoryRuleRespDto -> {
+//                    log.debug("노인 필수 규칙 자동 생성 완료");
+//                    return new ResponseEntity<>(ApiUtil.success(assistantMandatoryRuleRespDto), HttpStatus.CREATED);
+//                })
+//                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(context)));
+
+//처음 코드
+//        return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
+//                .map(assistantMandatoryRuleRespDto -> {
+//                    log.debug("노인 필수 규칙 자동 생성 완료");
+//                    return ResponseEntity
+//                            .status(HttpStatus.CREATED)
+//                            .body(ApiUtil.success(assistantMandatoryRuleRespDto));
+//                });
+//    }
     //알림 내역 조회
 
     @GetMapping("/emergency-alerts")

--- a/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverController.java
@@ -149,10 +149,12 @@ public class CaregiverController implements CaregiverControllerDocs {
                                                            BindingResult bindingResult,
                                                            @AuthenticationPrincipal LoginUser loginUser){
         return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
-                .map(assistantMandatoryRuleRespDto -> ResponseEntity
-                        .status(HttpStatus.CREATED)
-                        .body(ApiUtil.success(assistantMandatoryRuleRespDto))
-                );
+                .map(assistantMandatoryRuleRespDto -> {
+                    log.debug("노인 필수 규칙 자동 생성 완료. 응답: {}", assistantMandatoryRuleRespDto);
+                    return ResponseEntity
+                            .status(HttpStatus.CREATED)
+                            .body(ApiUtil.success(assistantMandatoryRuleRespDto));
+                });
     }
     //알림 내역 조회
 

--- a/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverControllerDocs.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverControllerDocs.java
@@ -203,16 +203,16 @@ public interface CaregiverControllerDocs {
     })
     ResponseEntity<?> getElderlyInfo(@PathVariable(name = "elderlyId")Long elderlyId, @AuthenticationPrincipal LoginUser loginUser);
 
-    @Operation(summary = "AI 어시스턴트 필수 규칙 자동 생성 ", description = "AI 어시스턴트 필수 규칙 자동 생성 요청: jwt 토큰 사용")
-    @ApiResponses( value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
-            @ApiResponse(responseCode = "401", description = "토큰 기간 만료", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
-            @ApiResponse(responseCode = "500", description = "GPT 메시지 생성 과정에서 에러 발생", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
-    })
-    Mono<ResponseEntity<?>> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
-                                                    @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
-                                                    BindingResult bindingResult,
-                                                    @AuthenticationPrincipal LoginUser loginUser);
+//    @Operation(summary = "AI 어시스턴트 필수 규칙 자동 생성 ", description = "AI 어시스턴트 필수 규칙 자동 생성 요청: jwt 토큰 사용")
+//    @ApiResponses( value = {
+//            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
+//            @ApiResponse(responseCode = "401", description = "토큰 기간 만료", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
+//            @ApiResponse(responseCode = "500", description = "GPT 메시지 생성 과정에서 에러 발생", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
+//    })
+//    Mono<ResponseEntity<ApiResult<AssistantMandatoryRuleRespDto>>> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
+//                                                    @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
+//                                                    BindingResult bindingResult,
+//                                                    @AuthenticationPrincipal LoginUser loginUser);
     @Operation(summary = "알림 내역 페이지 조회 ", description = "관리하는 노인 사용자가 발행한 알림 내역 조회: jwt 토큰 사용")
     @ApiResponses( value = {
             @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = EmergencyRequestListRespDto.class), mediaType = "application/json")),

--- a/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverControllerDocs.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/caregiver/CaregiverControllerDocs.java
@@ -203,16 +203,16 @@ public interface CaregiverControllerDocs {
     })
     ResponseEntity<?> getElderlyInfo(@PathVariable(name = "elderlyId")Long elderlyId, @AuthenticationPrincipal LoginUser loginUser);
 
-//    @Operation(summary = "AI 어시스턴트 필수 규칙 자동 생성 ", description = "AI 어시스턴트 필수 규칙 자동 생성 요청: jwt 토큰 사용")
-//    @ApiResponses( value = {
-//            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
-//            @ApiResponse(responseCode = "401", description = "토큰 기간 만료", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
-//            @ApiResponse(responseCode = "500", description = "GPT 메시지 생성 과정에서 에러 발생", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
-//    })
-//    Mono<ResponseEntity<ApiResult<AssistantMandatoryRuleRespDto>>> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
-//                                                    @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
-//                                                    BindingResult bindingResult,
-//                                                    @AuthenticationPrincipal LoginUser loginUser);
+    @Operation(summary = "AI 어시스턴트 필수 규칙 자동 생성 ", description = "AI 어시스턴트 필수 규칙 자동 생성 요청: jwt 토큰 사용")
+    @ApiResponses( value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "토큰 기간 만료", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
+            @ApiResponse(responseCode = "500", description = "GPT 메시지 생성 과정에서 에러 발생", content = @Content(schema = @Schema(implementation = AssistantMandatoryRuleReqDto.class), mediaType = "application/json")),
+    })
+    ResponseEntity<?> createAutoMandatoryRule(@PathVariable(name = "elderlyId")Long elderlyId,
+                                                    @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto,
+                                                    BindingResult bindingResult,
+                                                    @AuthenticationPrincipal LoginUser loginUser);
     @Operation(summary = "알림 내역 페이지 조회 ", description = "관리하는 노인 사용자가 발행한 알림 내역 조회: jwt 토큰 사용")
     @ApiResponses( value = {
             @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(schema = @Schema(implementation = EmergencyRequestListRespDto.class), mediaType = "application/json")),

--- a/src/main/java/com/develokit/maeum_ieum/controller/caregiver/ReactiveCaregiverController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/caregiver/ReactiveCaregiverController.java
@@ -1,2 +1,48 @@
-package com.develokit.maeum_ieum.controller.caregiver;public class ReactiveCaregiverController {
+package com.develokit.maeum_ieum.controller.caregiver;
+
+import com.develokit.maeum_ieum.dto.assistant.ReqDto;
+import com.develokit.maeum_ieum.dto.assistant.RespDto;
+import com.develokit.maeum_ieum.service.CaregiverService;
+import com.develokit.maeum_ieum.util.ApiUtil;
+import com.develokit.maeum_ieum.util.api.ApiResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import static com.develokit.maeum_ieum.dto.assistant.ReqDto.*;
+import static com.develokit.maeum_ieum.dto.assistant.RespDto.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reactive/caregivers")
+public class ReactiveCaregiverController {
+    private final CaregiverService caregiverService;
+    private final Logger log = LoggerFactory.getLogger(ReactiveCaregiverController.class);
+
+    @PostMapping("/elderlys/{elderlyId}/assistants/rules/autocomplete")
+    public Mono<ResponseEntity<ApiResult<AssistantMandatoryRuleRespDto>>> createAutoMandatoryRule(
+            @PathVariable(name = "elderlyId") Long elderlyId,
+            @Valid @RequestBody AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto) {
+
+        log.debug("디버그 : 노인 필수 규칙 자동 생성을 위한 리액티브 컨트롤러 진입 완료");
+
+
+        return ReactiveSecurityContextHolder.getContext()
+                .flatMap(securityContext -> {
+                    log.debug("Security Context: {}", securityContext.getAuthentication());
+                    return caregiverService.createAutoMandatoryRule(assistantMandatoryRuleReqDto)
+                            .map(assistantMandatoryRuleRespDto -> {
+                                log.debug("노인 필수 규칙 자동 생성 완료");
+                                return ResponseEntity.status(HttpStatus.CREATED)
+                                        .body(ApiUtil.success(assistantMandatoryRuleRespDto));
+                            });
+                });
+    }
+
 }

--- a/src/main/java/com/develokit/maeum_ieum/controller/caregiver/ReactiveCaregiverController.java
+++ b/src/main/java/com/develokit/maeum_ieum/controller/caregiver/ReactiveCaregiverController.java
@@ -1,0 +1,2 @@
+package com.develokit.maeum_ieum.controller.caregiver;public class ReactiveCaregiverController {
+}

--- a/src/main/java/com/develokit/maeum_ieum/service/CaregiverService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/CaregiverService.java
@@ -198,13 +198,18 @@ public class CaregiverService {
     }
 
 
-    // AI 필수 규칙 자동 생성
+    // TODO AI 필수 규칙 자동 생성 -> WebFlux
     public Mono<AssistantMandatoryRuleRespDto> createAutoMandatoryRule(AssistantMandatoryRuleReqDto assistantMandatoryRuleReqdto){
         return openAiService.createGptMessage(assistantMandatoryRuleReqdto)
                 .doOnError(CustomApiException.class, e ->{
                     log.error("AI 필수 규칙 자동 완성 응답 DTO 반환 중 오류 발생: "+e.getMessage());
                     throw new CustomApiException("AI 필수 규칙 자동 완성 응답 DTO 반환 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR);
                 });
+    }
+    // TODO AI 필수 규칙 자동 생성 -> Servlet
+
+    public AssistantMandatoryRuleRespDto createAutoMandatoryRuleWithFeign(AssistantMandatoryRuleReqDto assistantMandatoryRuleReqdto){
+        return openAiService.createGptMessageWithFeign(assistantMandatoryRuleReqdto);
     }
 
 

--- a/src/main/java/com/develokit/maeum_ieum/service/CaregiverService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/CaregiverService.java
@@ -200,7 +200,11 @@ public class CaregiverService {
 
     // AI 필수 규칙 자동 생성
     public Mono<AssistantMandatoryRuleRespDto> createAutoMandatoryRule(AssistantMandatoryRuleReqDto assistantMandatoryRuleReqdto){
-        return openAiService.createGptMessage(assistantMandatoryRuleReqdto);
+        return openAiService.createGptMessage(assistantMandatoryRuleReqdto)
+                .doOnError(CustomApiException.class, e ->{
+                    log.error("AI 필수 규칙 자동 완성 응답 DTO 반환 중 오류 발생: "+e.getMessage());
+                    throw new CustomApiException("AI 필수 규칙 자동 완성 응답 DTO 반환 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR);
+                });
     }
 
 

--- a/src/main/java/com/develokit/maeum_ieum/service/ElderlyService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/ElderlyService.java
@@ -154,10 +154,12 @@ public class ElderlyService {
 
         //스레드가 있는지 확인 -> 없으면 스레드 생성
         if(!assistantPS.hasThread()){ //스레드 없음
+            log.debug("디버그 : 해당 AI 어시스턴트는 스레드 없으므로 스레드 생성");
             ThreadRespDto threadRespDto = openAiService.createThread();
             assistantPS.attachThread(threadRespDto.getId());
         }
         else{ //스레드가 있다면
+            log.debug("디버그 : 해당 AI 어시스턴트는 스레드가 존재함");
             LocalDateTime lastChatTime = elderlyPS.getLastChatTime();
             //이전 응답 기록이 없다면
             if (lastChatTime == null) {
@@ -166,15 +168,20 @@ public class ElderlyService {
 
                 //스레드 생성일로부터 30일이 지남
                 if(ChronoUnit.DAYS.between(threadCreatedDate, LocalDateTime.now()) >= 30){
+                    log.debug("디버그 : 해당 AI 어시스턴트는 스레드 생성일로부터 30일이 지났고, 이전 대화 기록이 없으므로 새 스레드 생성");
                     ThreadRespDto threadRespDto = openAiService.createThread();
                     assistantPS.attachThread(threadRespDto.getId());
                 }
+                //스레드 생성일로부터 30일이 지나지 않으면 그대로 반환
 
             } else { //이전 응답 기록이 있다면
+                //마지막 대화일로부터 30일이 지났는지 확인
                 if(ChronoUnit.DAYS.between(lastChatTime, LocalDateTime.now()) >= 30){
+                    log.debug("디버그 : 해당 AI 어시스턴트는 마지막 대화로부터 30일이 지났으므로 새 스레드 생성");
                     ThreadRespDto threadRespDto = openAiService.createThread();
                     assistantPS.attachThread(threadRespDto.getId());
                 }
+                //마지막 대화일로부터 30일이 지나지 않았으므로 그대로 반환
             }
         }
 

--- a/src/main/java/com/develokit/maeum_ieum/service/ElderlyService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/ElderlyService.java
@@ -159,10 +159,22 @@ public class ElderlyService {
         }
         else{ //스레드가 있다면
             LocalDateTime lastChatTime = elderlyPS.getLastChatTime();
-            //마지막 접근일로부터 30일이 지났는지 검증 -> 지났다면 새로운 스레드 생성
-            if(ChronoUnit.DAYS.between(lastChatTime, LocalDateTime.now()) >= 30){
-                ThreadRespDto threadRespDto = openAiService.createThread();
-                assistantPS.attachThread(threadRespDto.getId());
+            //이전 응답 기록이 없다면
+            if (lastChatTime == null) {
+                //스레드 생성일로부터 30일이 지났는지 검증 -> 지났다면 새로운 스레드 생성
+                LocalDateTime threadCreatedDate = assistantPS.getThreadCreatedDate();
+
+                //스레드 생성일로부터 30일이 지남
+                if(ChronoUnit.DAYS.between(threadCreatedDate, LocalDateTime.now()) >= 30){
+                    ThreadRespDto threadRespDto = openAiService.createThread();
+                    assistantPS.attachThread(threadRespDto.getId());
+                }
+
+            } else { //이전 응답 기록이 있다면
+                if(ChronoUnit.DAYS.between(lastChatTime, LocalDateTime.now()) >= 30){
+                    ThreadRespDto threadRespDto = openAiService.createThread();
+                    assistantPS.attachThread(threadRespDto.getId());
+                }
             }
         }
 

--- a/src/main/java/com/develokit/maeum_ieum/service/OpenAiService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/OpenAiService.java
@@ -124,6 +124,7 @@ public class OpenAiService {
             )).map(AssistantMandatoryRuleRespDto::new);
 
         }catch (Exception e){
+            log.error("GPT 자동 생성 필수 규칙 반환 중 오류 발생: "+e.getMessage());
             throw new CustomApiException("OPENAI_SERVER_ERROR", 500, HttpStatus.INTERNAL_SERVER_ERROR);
 
         }

--- a/src/main/java/com/develokit/maeum_ieum/service/OpenAiService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/OpenAiService.java
@@ -1,6 +1,7 @@
 package com.develokit.maeum_ieum.service;
 
 import com.develokit.maeum_ieum.config.openAI.AssistantFeignClient;
+import com.develokit.maeum_ieum.config.openAI.GptFeignClient;
 import com.develokit.maeum_ieum.config.openAI.GptWebClient;
 import com.develokit.maeum_ieum.config.openAI.ThreadFeignClient;
 import com.develokit.maeum_ieum.domain.assistant.Assistant;
@@ -24,6 +25,7 @@ import static com.develokit.maeum_ieum.dto.openAi.assistant.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.assistant.RespDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.gpt.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.gpt.ReqDto.CreateGptMessageReqDto.*;
+import static com.develokit.maeum_ieum.dto.openAi.gpt.RespDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.thread.ReqDto.*;
 import static com.develokit.maeum_ieum.dto.openAi.thread.RespDto.*;
 
@@ -36,6 +38,7 @@ public class OpenAiService {
     private final AssistantFeignClient assistantFeignClient;
     private final ThreadFeignClient threadFeignClient;
     private final GptWebClient gptWebClient;
+    private final GptFeignClient gptFeignClient;
     private final String MODEL = "gpt-4o";
     private final int MAX_TOKENS = 400;
 
@@ -113,7 +116,7 @@ public class OpenAiService {
             throw new CustomApiException("OPENAI_SERVER_ERROR", 500, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-    //TODO gpt한테 필수 규칙 더 상세하게 생성해달라는 요청
+    //TODO gpt한테 필수 규칙 더 상세하게 생성해달라는 요청 -> WebFlux버전
     public Mono<AssistantMandatoryRuleRespDto> createGptMessage(AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto){
         try{
            return gptWebClient.createGptMessage(new CreateGptMessageReqDto(
@@ -129,6 +132,29 @@ public class OpenAiService {
 
         }
     }
+
+    //TODO gpt한테 필수 규칙 더 상세하게 생성해달라는 요청 -> 서블릿 버전
+    public AssistantMandatoryRuleRespDto createGptMessageWithFeign(AssistantMandatoryRuleReqDto assistantMandatoryRuleReqDto){
+        log.debug("GPT 자동 생성 필수 규칙 요청 전송: {}", assistantMandatoryRuleReqDto.getContent());
+        try{
+            CreateGptMessageRespDto gptMessage = gptFeignClient.createGptMessage(new CreateGptMessageReqDto(
+                    MODEL,
+                    new MessageDto(SYSTEM_PROMPT, "system"),
+                    new MessageDto(assistantMandatoryRuleReqDto.getContent() + USER_PROMPT_SUFFIX, "user"),
+                    MAX_TOKENS)
+            );
+            return new AssistantMandatoryRuleRespDto(gptMessage);
+
+        }catch (FeignException fe){
+            log.error("OpenAI API 호출 과정에서 에러 발생. Status: {}, Body: {}", fe.status(), fe.contentUTF8(), fe);
+            throw new CustomApiException("OPENAI_SERVER_ERROR", fe.status(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        catch (Exception e){
+            log.error("GPT 자동 생성 필수 규칙 반환 중 오류 발생: "+e.getMessage());
+            throw new CustomApiException("OPENAI_SERVER_ERROR", 500, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
 
 
 

--- a/src/test/java/com/develokit/maeum_ieum/service/CaregiverServiceTest.java
+++ b/src/test/java/com/develokit/maeum_ieum/service/CaregiverServiceTest.java
@@ -114,7 +114,7 @@ class CaregiverServiceTest {
         );
 
         when(careGiverRepository.findByUsername(username)).thenReturn(Optional.of(caregiver));
-        when(elderlyRepository.findByCaregiverIdAndIdAfter(eq(1L), eq(0L), any(PageRequest.class)))
+        when(elderlyRepository.findByCaregiverIdAndIdLessThanEqual(eq(1L), eq(0L), any(PageRequest.class)))
                 .thenReturn(elderlyList);
 
         // When


### PR DESCRIPTION
## 1. gpt 규칙 자동 생성 api
-> 비동기 처리로 인한 SecurityContext 손실 문제로 추정
원래 요청을 처리하던 스레드의 ThreadLocal 정보가 새로운 스레드로 전달되지 않아서 초기에 로그인 시큐리티 인증 세션은 통과됐지만 응답이 반환될 때의 스레드에  SecurityContext 정보가 없어서 인증 문제가 발생한 것으로 보임

### 시도 1)
SecurityContext를 Mono로 감싸서 내보내는 방식으로 수정
그러나 스레드 전환 시 인증 정보가 소실되었는지 여전히 인증 문제 발생

### 시도 2)
ReactiveSecurityContextHolder를 사용해 SecurityContext 유지하는 방식으로 수정
여전히 인증 문제 발생

### 시도 3)
WebFlux만 처리하도록 기존 SecurityConfig를 분리
WebFluxSecurityConfig에 @Order(1)를 걸고 type = ConditionalOnWebApplication.Type.REACTIVE로 조건부 실행 설정한 후   application.yaml에 
```
spring:
  main:
    web-application-type: reactive 
```
설정해서 '/reactive' 경로로 시작하는 요청만 WebFlux로 처리하도록 설정. 여전히 안됨.

### 시도 4)
WebConfig 생성해서 "/reactive"로 시작하는 경로만 WebFlux로 처리되고, 나머지는 MVC로 처리하도록 설정. 여전히 안됨
조건부 실행 어노테이션 제거. 빈 오버라이딩 문제 발생

### 결론
WebFlux와 MVC 설정을 같이 가져가려고 했으나 해결이 안되어 기존 요청을 feign을 통해 보내도록 변경

## 2. 채팅방 입장 시 스레드 검증 api
이전 채팅 내역 기준으로만 스레드 검증을 진행했어서 채팅 내역이 없는 경우 문제 발생함
따라서 이전 채팅 내역이 없는 경우 스레드 생성일로부터 만료 기간이 지났는지 검증하도록 추가

## 3. Jwt 관련 에러 핸들링
이전 @RequireAuth를 통해 인증 작업을 진행했던 방식을 전면 수정함에 따라 JwtAuthorizationFilter 내에서 jwt 에러 핸들링 후 에러 응답 반환하도록 수정
