### PR TITLE
노인 삭제 오류 수정

### DIFF
--- a/src/main/java/com/develokit/maeum_ieum/domain/emergencyRequest/EmergencyRequestRepository.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/emergencyRequest/EmergencyRequestRepository.java
@@ -27,7 +27,15 @@ public interface EmergencyRequestRepository extends JpaRepository<EmergencyReque
 
     List<EmergencyRequest> findByElderly(Elderly elderly);
 
+//    @Modifying(clearAutomatically = true)
+//    @Query("delete from EmergencyRequest er where er.elderly = :elderly")
+//    void deleteAllByElderly(@Param("elderly") Elderly elderly);
+
     @Modifying(clearAutomatically = true)
     @Query("delete from EmergencyRequest er where er.elderly = :elderly")
-    void deleteAllByElderly(@Param("elderly") Elderly elderly);
+    int deleteAllByElderly(@Param("elderly") Elderly elderly);
+    @Query("SELECT er FROM EmergencyRequest er JOIN FETCH er.elderly e WHERE e = :elderly")
+    List<EmergencyRequest> findByElderlyWithFetch(@Param("elderly") Elderly elderly);
+
+
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/report/ReportRepository.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/report/ReportRepository.java
@@ -75,8 +75,12 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findByElderly(Elderly eldelry);
 
 
+//    @Modifying
+//    @Query("DELETE FROM Report r WHERE r.elderly = :elderly")
+//    void deleteAllByElderly(@Param("elderly") Elderly elderly);
+
     @Modifying
     @Query("DELETE FROM Report r WHERE r.elderly = :elderly")
-    void deleteAllByElderly(@Param("elderly") Elderly elderly);
+    int deleteAllByElderly(@Param("elderly") Elderly elderly);
 
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/user/caregiver/CareGiverRepository.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/user/caregiver/CareGiverRepository.java
@@ -16,6 +16,10 @@ public interface CareGiverRepository extends JpaRepository<Caregiver, Long> {
     @Query("select c from Caregiver c where c.username = :username")
     Optional<Caregiver> findByUsername(@Param(value = "username")String username);
 
+
+    @Query("SELECT c FROM Caregiver c LEFT JOIN FETCH c.elderlyList WHERE c.username = :username")
+    Optional<Caregiver> findByUsernameWithElderlys(@Param("username") String username);
+
     @Query("select c from Caregiver c")
     List<Caregiver> findAll();
 
@@ -24,4 +28,7 @@ public interface CareGiverRepository extends JpaRepository<Caregiver, Long> {
 
     @Query("select c from Caregiver c join fetch c.elderlyList where c.id = :caregiverId")
     Caregiver findCaregiverWithElderlys(@Param("caregiverId") Long caregiverId);
+
+    @Query("select c from Caregiver c join fetch c.emergencyRequestList where c.id = :caregiverId")
+    Caregiver findCaregiverWithEmergencyRequests(@Param("caregiverId") Long caregiverId);
 }

--- a/src/main/java/com/develokit/maeum_ieum/domain/user/elderly/Elderly.java
+++ b/src/main/java/com/develokit/maeum_ieum/domain/user/elderly/Elderly.java
@@ -55,10 +55,10 @@ public class Elderly extends User {
 
     private LocalDateTime lastChatTime; //마지막 대화 날짜
 
-    @OneToMany(mappedBy = "elderly", orphanRemoval = true)
+    @OneToMany(mappedBy = "elderly", orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Report> weeklyReports = new ArrayList<>(); //주간 보고서
 
-    @OneToMany(mappedBy = "elderly", orphanRemoval = true)
+    @OneToMany(mappedBy = "elderly", orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Report> monthlyReports = new ArrayList<>(); //월간 보고서
 
     //TODO -> 프론트에서 추가하는 화면 구현하면 연결할것

--- a/src/main/java/com/develokit/maeum_ieum/dto/elderly/RespDto.java
+++ b/src/main/java/com/develokit/maeum_ieum/dto/elderly/RespDto.java
@@ -28,8 +28,8 @@ public class RespDto {
     @Getter
     @Schema(description = "요양사 삭제 응답 DTO")
     public static class ElderlyDeleteRespDto{
-        public ElderlyDeleteRespDto(Elderly elderly) {
-            this.elderlyName = elderly.getName();
+        public ElderlyDeleteRespDto(String elderlyName) {
+            this.elderlyName = elderlyName;
             this.deleted = true;
         }
 

--- a/src/main/java/com/develokit/maeum_ieum/dummy/DummyObject.java
+++ b/src/main/java/com/develokit/maeum_ieum/dummy/DummyObject.java
@@ -6,6 +6,7 @@ import com.develokit.maeum_ieum.domain.emergencyRequest.EmergencyType;
 import com.develokit.maeum_ieum.domain.message.Message;
 import com.develokit.maeum_ieum.domain.message.MessageType;
 import com.develokit.maeum_ieum.domain.report.Report;
+import com.develokit.maeum_ieum.domain.report.ReportStatus;
 import com.develokit.maeum_ieum.domain.report.ReportType;
 import com.develokit.maeum_ieum.domain.report.indicator.*;
 import com.develokit.maeum_ieum.domain.user.Gender;
@@ -27,6 +28,10 @@ import java.util.List;
 
 public class DummyObject {
 
+    protected EmergencyRequest mockEmergencyRequest(Elderly elderly, Caregiver caregiver){
+        return EmergencyRequest.builder().elderly(elderly).caregiver(caregiver).emergencyType(EmergencyType.CAREGIVER_NOTIFY).build();
+    }
+
     protected Report mockMonthlyReport(Elderly elderly) throws JsonProcessingException {
 
         LocalDateTime endDate = LocalDateTime.now();
@@ -44,6 +49,7 @@ public class DummyObject {
                 .psychologicalStabilityIndicator(PsychologicalStabilityIndicator.VERY_POOR)
                 .socialConnectivityIndicator(SocialConnectivityIndicator.GOOD)
                 .supportNeedsIndicator(SupportNeedsIndicator.FAIR)
+                .reportStatus(ReportStatus.COMPLETED)
                 .memo("유우시군을 분석했어🤍")
                 .build();
 
@@ -74,6 +80,7 @@ public class DummyObject {
                 .psychologicalStabilityIndicator(PsychologicalStabilityIndicator.VERY_POOR)
                 .socialConnectivityIndicator(SocialConnectivityIndicator.GOOD)
                 .supportNeedsIndicator(SupportNeedsIndicator.FAIR)
+                .reportStatus(ReportStatus.COMPLETED)
                 .memo("유우시군을 분석했어🤍")
                 .build();
 
@@ -100,6 +107,7 @@ public class DummyObject {
                 .psychologicalStabilityIndicator(PsychologicalStabilityIndicator.VERY_POOR)
                 .socialConnectivityIndicator(SocialConnectivityIndicator.GOOD)
                 .supportNeedsIndicator(SupportNeedsIndicator.FAIR)
+                .reportStatus(ReportStatus.COMPLETED)
                 .memo("유우시군을 분석했어🤍")
                 .build();
 
@@ -183,7 +191,6 @@ public class DummyObject {
         return EmergencyRequest.builder()
                 .caregiver(caregiver)
                 .elderly(elderly)
-                .id(1L)
                 .emergencyType(EmergencyType.CAREGIVER_NOTIFY)
                 .build();
     }
@@ -231,7 +238,6 @@ public class DummyObject {
     protected Elderly newElderly(Caregiver caregiver,Long elderlyId){
         return Elderly.builder()
                 .name("노인1")
-                .id(elderlyId)
                 .role(Role.USER)
                 .contact("010-1111-3333")
                 .healthInfo("탕후루")

--- a/src/main/java/com/develokit/maeum_ieum/service/report/ReportService.java
+++ b/src/main/java/com/develokit/maeum_ieum/service/report/ReportService.java
@@ -167,6 +167,9 @@ public class ReportService {
     @Transactional
     public void generateReportContent(Report report) throws JsonProcessingException {
 
+
+
+
         //어쩌구저쩌구
         report.setQualitativeAnalysis("정성적 보고서 분석 결과");
 

--- a/src/test/java/com/develokit/maeum_ieum/controller/CaregiverControllerTest.java
+++ b/src/test/java/com/develokit/maeum_ieum/controller/CaregiverControllerTest.java
@@ -37,6 +37,8 @@ class CaregiverControllerTest extends DummyObject {
     @Autowired MockMvc mvc;
     @Autowired ObjectMapper om;
 
+
+
     @Test
     @WithUserDetails(setupBefore = TestExecutionEvent.TEST_EXECUTION, value = "user6666")
     void 월간보고서_정량적평가_조회_테스트() throws Exception{

--- a/src/test/java/com/develokit/maeum_ieum/domain/report/ReportRepositoryTest.java
+++ b/src/test/java/com/develokit/maeum_ieum/domain/report/ReportRepositoryTest.java
@@ -1,10 +1,13 @@
 package com.develokit.maeum_ieum.domain.report;
 
+import com.develokit.maeum_ieum.domain.emergencyRequest.EmergencyRequest;
+import com.develokit.maeum_ieum.domain.emergencyRequest.EmergencyRequestRepository;
 import com.develokit.maeum_ieum.domain.user.elderly.Elderly;
 import com.develokit.maeum_ieum.domain.user.elderly.ElderlyRepository;
 import com.develokit.maeum_ieum.dummy.DummyObject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -31,19 +34,49 @@ class ReportRepositoryTest extends DummyObject {
     @Autowired
     private ElderlyRepository elderlyRepository;
 
+    @Autowired private EmergencyRequestRepository emergencyRequestRepository;
+
+
     @Autowired private EntityManager em;
+
+    @BeforeEach
+    void setUp(){
+
+    }
+
+    @Test
+    @Rollback(value = false)
+    @Transactional
+    void 긴급알림추가하기(){
+        Optional<Elderly> elderly = elderlyRepository.findById(34L);
+
+        Elderly elderlyPS = elderly.get();
+
+        for(int i = 0;i<10;i++) {
+            EmergencyRequest emergencyRequest = newMockEmergencyRequest(elderlyPS, elderlyPS.getCaregiver());
+            em.persist(emergencyRequest);
+        }
+    }
 
     @Test
     @Rollback(value = false)
     @Transactional
     void 테스트용_주간보고서_생성하기() throws JsonProcessingException {
-        Optional<Elderly> elderly = elderlyRepository.findById(34L);
+        Optional<Elderly> elderly = elderlyRepository.findById(66L);
 
         Elderly elderlyPS = elderly.get();
 
-        Report report = mockWeeklyReport(elderlyPS);
+        for(int i = 0;i<10;i++) {
+            Report report = mockWeeklyReport(elderlyPS);
+            em.persist(report);
+        }
 
-        em.persist(report);
+        for(int i = 0;i<10;i++) {
+            Report report = mockMonthlyReport(elderlyPS);
+            em.persist(report);
+        }
+
+
     }
 
     @Test


### PR DESCRIPTION
트랜잭션 범위 전파 문제인 것으로 추정
클래스 레벨에 트랜잭션을 걸어서 메서드 내 삭제 작업 전체를 커버하는 것 같음

다중 컬렉션 동시 로딩 지원 안하니까 별도로 elderlyList 페치 조인 후 assistantList 페치조인 쿼리로 삭제 작업 진행했는데 왜 컬렉션 iterator를 통한 강제 초기화가 동작(수정 전 방식)하지 않는지는 모르겠음 트랜잭션이 메서드 레벨에 걸려있었어서 중간에 관리가 끊긴 건지는 찾아봐야 할듯

 